### PR TITLE
Feat soft 41 EPIC (#15)

### DIFF
--- a/README.md
+++ b/README.md
@@ -249,11 +249,11 @@ php artisan container:graph --print-cypher
 
 ### Graph model
 
-- `(:Interface:Abstract)-[:BINDS_TO {shared}]->(:Class:Abstract)` when the binding key is an interface
-- `(:Class:Abstract)-[:BINDS_TO {shared}]->(:Class:Abstract)` when the binding key is a class
+- `(:Interface:Abstract)-[:BINDS_TO {type}]->(:Class:Abstract)` when the binding key is an interface (`type`: `normal` or `singleton`)
+- `(:Class:Abstract)-[:BINDS_TO {type}]->(:Class:Abstract)` when the binding key is a class
 - `(:Class:Abstract)` class nodes are also added for discovered project classes (PSR-4 autoloaded classes from the app)
 - **`Abstract`** – use as the entry label to start from registered binding keys and walk the graph (`MATCH (a:Abstract) …`).
-- `(:Class:Abstract)-[:DEPENDS_ON]->(:Class:Abstract|:Interface:Abstract|:UnresolvedDependency:Abstract)`
+- `(:Class:Abstract)-[:DEPENDS_ON {type}]->(:Class:Abstract|:Interface:Abstract|:UnresolvedDependency:Abstract)` — `type` values: `constructor_injection`, `method_injection`, `facade`, `global_helper`, `service_location`, `instantiation`
 - `(:UnresolvedDependency:Abstract {name, reason})`
 
 ### Example Cypher queries
@@ -264,7 +264,7 @@ For ad-hoc exploration you can still use **read-cypher**. For Laravel DI questio
 { "class": "App\\Services\\FooService", "direction": "outbound", "depth": 4, "page": 1, "per_page": 100 }
 ```
 
-Returns structured JSON with `dependencies`, `dependents`, `binding`, pagination metadata (`dependencies_pagination` / `dependents_pagination`), and `graph_export_required` when data is missing. Default page size is 100 entries.
+Returns structured JSON with `dependencies`, `dependents`, `binding` (each includes relationship `type`), pagination metadata (`dependencies_pagination` / `dependents_pagination`), and `graph_export_required` when data is missing. Default page size is 100 entries. Legacy graphs without `type` return inferred values with `confidence: inferred`; re-run `container:graph` after upgrading.
 
 **Explore from container binding keys outward (graph view in Neo4j Browser):**
 

--- a/resources/boost/guidelines/core.blade.php
+++ b/resources/boost/guidelines/core.blade.php
@@ -49,6 +49,8 @@ Env vars for direct Neo4j connection: set `NEO4J_URI` (and user/password), or se
 
 **get-class-dependency-graph** (MCP tool): pass a fully-qualified class name to get structured DI dependencies/dependents from the exported graph. Prerequisite: run `php artisan container:graph` first. Example argument: `{ "class": "App\\\\Services\\\\FooService", "direction": "outbound", "page": 1, "per_page": 100 }`.
 
+**Relationship `type` glossary** (on `DEPENDS_ON` / `BINDS_TO` edges): `constructor_injection` (typed constructor param), `method_injection` (typed method param), `facade` (static facade call), `global_helper` (`cache()` / `auth()` / `view()`), `service_location` (`app()` / `resolve()` / `App::make()`), `instantiation` (direct `new`). Bindings: `normal` (transient bind) or `singleton` (shared instance). Legacy graphs without `type` are inferred as `constructor_injection` / `normal` with `confidence: inferred` — re-run `container:graph` after upgrades.
+
 ```env
 NEO4J_URI=bolt://localhost:7687
 NEO4J_USER=neo4j

--- a/src/Boost/Tools/GetClassDependencyGraphTool.php
+++ b/src/Boost/Tools/GetClassDependencyGraphTool.php
@@ -11,6 +11,7 @@ use Laravel\Mcp\Response;
 use Laravel\Mcp\Server\Tool;
 use Laravel\Mcp\Server\Tools\Annotations\IsReadOnly;
 use Neo4j\LaravelBoost\ClassDependencyGraphReader;
+use Neo4j\LaravelBoost\Support\Graph\GraphRelationshipGlossary;
 use Throwable;
 
 #[IsReadOnly]
@@ -18,7 +19,7 @@ final class GetClassDependencyGraphTool extends Tool
 {
     protected string $name = 'get-class-dependency-graph';
 
-    protected string $description = 'Returns the Laravel container dependency graph for a fully-qualified PHP class: constructor dependencies, binding targets, dependents, and unresolved types. Requires php artisan container:graph to have exported data to Neo4j. Use when exploring architecture, DI wiring, or "what depends on / is injected into X?"';
+    protected string $description = 'Returns the Laravel container dependency graph for a fully-qualified PHP class: constructor dependencies, binding targets, dependents, and unresolved types. Requires php artisan container:graph to have exported data to Neo4j. Use when exploring architecture, DI wiring, or "what depends on / is injected into X?".'.GraphRelationshipGlossary::MCP_TOOL_DESCRIPTION_SUFFIX;
 
     public function __construct(
         private ClassDependencyGraphReader $reader,

--- a/src/ClassDependencyGraphReader.php
+++ b/src/ClassDependencyGraphReader.php
@@ -4,6 +4,7 @@ namespace Neo4j\LaravelBoost;
 
 use Laudis\Neo4j\Types\CypherList;
 use Neo4j\LaravelBoost\Support\ContainerGraphConnection;
+use Neo4j\LaravelBoost\Support\Graph\RelationshipTypeReader;
 
 class ClassDependencyGraphReader
 {
@@ -82,14 +83,14 @@ class ClassDependencyGraphReader
     }
 
     /**
-     * @return null|array{abstract: string, concrete: string, shared: bool}
+     * @return null|array{abstract: string, concrete: string, shared: bool, type: string, confidence?: string}
      */
     private function fetchBinding(string $class): ?array
     {
         $binding = $this->fetchBindingFromQuery(
             <<<'CYPHER'
 MATCH (a:Abstract {name: $class})-[r:BINDS_TO]->(t:Abstract)
-RETURN a.name AS abstract, t.name AS concrete, r.shared AS shared
+RETURN a.name AS abstract, t.name AS concrete, r.type AS type, r.shared AS shared
 LIMIT 1
 CYPHER,
             ['class' => $class],
@@ -102,7 +103,7 @@ CYPHER,
         return $this->fetchBindingFromQuery(
             <<<'CYPHER'
 MATCH (a:Abstract)-[r:BINDS_TO]->(t:Abstract {name: $class})
-RETURN a.name AS abstract, t.name AS concrete, r.shared AS shared
+RETURN a.name AS abstract, t.name AS concrete, r.type AS type, r.shared AS shared
 LIMIT 1
 CYPHER,
             ['class' => $class],
@@ -111,18 +112,27 @@ CYPHER,
 
     /**
      * @param  array<string, mixed>  $parameters
-     * @return null|array{abstract: string, concrete: string, shared: bool}
+     * @return null|array{abstract: string, concrete: string, shared: bool, type: string, confidence?: string}
      */
     private function fetchBindingFromQuery(string $cypher, array $parameters): ?array
     {
         $result = $this->connection->run($cypher, $parameters);
 
         foreach ($result as $record) {
-            return [
+            $typeMeta = RelationshipTypeReader::bindsTo($record->get('type'), $record->get('shared'));
+
+            $binding = [
                 'abstract' => (string) $record->get('abstract'),
                 'concrete' => (string) $record->get('concrete'),
-                'shared' => (bool) $record->get('shared'),
+                'shared' => $typeMeta['shared'],
+                'type' => $typeMeta['type'],
             ];
+
+            if (isset($typeMeta['confidence'])) {
+                $binding['confidence'] = $typeMeta['confidence'];
+            }
+
+            return $binding;
         }
 
         return null;
@@ -251,10 +261,10 @@ CYPHER,
         $cypher = sprintf(
             <<<'CYPHER'
 MATCH path = (c:Abstract {name: $class})%s(d:Abstract)
-WITH d, min(length(path)) AS depth
+WITH d, min(length(path)) AS depth, [rel IN relationships(path) | rel.type][-1] AS type
 ORDER BY depth ASC, d.name ASC
 SKIP $skip LIMIT $limit
-RETURN d.name AS name, labels(d) AS labels, d.kind AS kind, depth
+RETURN d.name AS name, labels(d) AS labels, d.kind AS kind, depth, type
 CYPHER,
             sprintf($relationship, $depth),
         );
@@ -275,8 +285,8 @@ CYPHER,
     {
         $result = $this->connection->run(
             <<<'CYPHER'
-MATCH (c:Abstract {name: $class})-[:DEPENDS_ON]->(u:UnresolvedDependency:Abstract)
-RETURN u.name AS name, u.reason AS reason
+MATCH (c:Abstract {name: $class})-[r:DEPENDS_ON]->(u:UnresolvedDependency:Abstract)
+RETURN u.name AS name, u.reason AS reason, r.type AS type
 ORDER BY u.name ASC
 CYPHER,
             ['class' => $class],
@@ -290,6 +300,7 @@ CYPHER,
                 'relationship' => 'DEPENDS_ON',
                 'reason' => (string) $record->get('reason'),
                 'depth' => 1,
+                ...RelationshipTypeReader::dependsOn($record->get('type')),
             ];
         }
 
@@ -314,6 +325,7 @@ CYPHER,
                 'kind' => $this->resolveNodeKind($labelList, $record->get('kind')),
                 'relationship' => $relationship,
                 'depth' => (int) $record->get('depth'),
+                ...RelationshipTypeReader::dependsOn($record->get('type')),
             ];
         }
 

--- a/src/Console/ContainerGraphCommand.php
+++ b/src/Console/ContainerGraphCommand.php
@@ -5,6 +5,8 @@ namespace Neo4j\LaravelBoost\Console;
 use Closure;
 use Illuminate\Console\Command;
 use Neo4j\LaravelBoost\ContainerGraphWriter;
+use Neo4j\LaravelBoost\Support\Graph\BindsToType;
+use Neo4j\LaravelBoost\Support\Graph\DependsOnType;
 use RecursiveDirectoryIterator;
 use RecursiveIteratorIterator;
 use ReflectionClass;
@@ -62,7 +64,7 @@ class ContainerGraphCommand extends Command
     }
 
     /**
-     * @return array{0: array<int, array{abstract: string, abstractKind: string, concrete: string, concreteKind: string, shared: bool}>, 1: array<int, string>}
+     * @return array{0: array<int, array{abstract: string, abstractKind: string, concrete: string, concreteKind: string, shared: bool, type: string}>, 1: array<int, string>}
      */
     private function extractBindingRows(): array
     {
@@ -77,12 +79,15 @@ class ContainerGraphCommand extends Command
                 continue;
             }
 
+            $shared = (bool) ($binding['shared'] ?? false);
+
             $rows[] = [
                 'abstract' => $abstract,
                 'abstractKind' => $this->kindForTypeName($abstract),
                 'concrete' => $resolved['name'],
                 'concreteKind' => $resolved['kind'],
-                'shared' => (bool) ($binding['shared'] ?? false),
+                'shared' => $shared,
+                'type' => BindsToType::fromShared($shared)->value,
             ];
 
             if ($resolved['kind'] === 'Class' && class_exists($resolved['name']) && ! interface_exists($resolved['name'])) {
@@ -180,7 +185,7 @@ class ContainerGraphCommand extends Command
 
     /**
      * @param  array<int, string>  $classes
-     * @return array{0: array<int, array{class: string, dependency: string, dependencyKind: string}>, 1: array<int, array{class: string, name: string, reason: string}>}
+     * @return array{0: array<int, array{class: string, dependency: string, dependencyKind: string, type: string}>, 1: array<int, array{class: string, name: string, reason: string, type: string}>}
      */
     private function extractDependencyRows(array $classes): array
     {
@@ -210,12 +215,14 @@ class ContainerGraphCommand extends Command
                         'class' => $className,
                         'name' => $name,
                         'reason' => $reason ?? 'unresolved',
+                        'type' => DependsOnType::ConstructorInjection->value,
                     ];
                 } else {
                     $dependencyRows[] = [
                         'class' => $className,
                         'dependency' => $name,
                         'dependencyKind' => $kind,
+                        'type' => DependsOnType::ConstructorInjection->value,
                     ];
                 }
             }
@@ -364,8 +371,8 @@ class ContainerGraphCommand extends Command
 
     /**
      * @param  array<int, array{class: string}>  $classRows
-     * @param  array<int, array{abstract: string, abstractKind: string, concrete: string, concreteKind: string, shared: bool}>  $bindingRows
-     * @param  array<int, array{class: string, dependency: string, dependencyKind: string}>  $dependencyRows
+     * @param  array<int, array{abstract: string, abstractKind: string, concrete: string, concreteKind: string, shared: bool, type: string}>  $bindingRows
+     * @param  array<int, array{class: string, dependency: string, dependencyKind: string, type: string}>  $dependencyRows
      * @param  array<int, array{class: string, name: string, reason: string}>  $unresolvedRows
      */
     private function printCypher(ContainerGraphWriter $writer, array $classRows, array $bindingRows, array $dependencyRows, array $unresolvedRows): void

--- a/src/ContainerGraphWriter.php
+++ b/src/ContainerGraphWriter.php
@@ -3,6 +3,8 @@
 namespace Neo4j\LaravelBoost;
 
 use Neo4j\LaravelBoost\Support\ContainerGraphConnection;
+use Neo4j\LaravelBoost\Support\Graph\BindsToType;
+use Neo4j\LaravelBoost\Support\Graph\DependsOnType;
 
 class ContainerGraphWriter
 {
@@ -32,7 +34,7 @@ WITH row
 MATCH (a:Abstract {name: row.abstract})
 MATCH (c:Abstract {name: row.concrete})
 MERGE (a)-[r:BINDS_TO]->(c)
-SET r.shared = row.shared
+SET r.type = row.type
 CYPHER;
 
     private const CYPHER_CLASSES = <<<'CYPHER'
@@ -45,11 +47,13 @@ UNWIND $rows AS row
 MERGE (c:Class:Abstract {name: row.class})
 FOREACH (_ IN CASE WHEN row.dependencyKind = 'Interface' THEN [1] ELSE [] END |
   MERGE (d:Interface:Abstract {name: row.dependency})
-  MERGE (c)-[:DEPENDS_ON]->(d)
+  MERGE (c)-[r:DEPENDS_ON]->(d)
+  SET r.type = row.type
 )
 FOREACH (_ IN CASE WHEN row.dependencyKind <> 'Interface' THEN [1] ELSE [] END |
   MERGE (d:Class:Abstract {name: row.dependency})
-  MERGE (c)-[:DEPENDS_ON]->(d)
+  MERGE (c)-[r:DEPENDS_ON]->(d)
+  SET r.type = row.type
 )
 CYPHER;
 
@@ -58,7 +62,8 @@ UNWIND $rows AS row
 MERGE (c:Class:Abstract {name: row.class})
 MERGE (u:UnresolvedDependency:Abstract {name: row.name})
 SET u.reason = row.reason
-MERGE (c)-[:DEPENDS_ON]->(u)
+MERGE (c)-[r:DEPENDS_ON]->(u)
+SET r.type = row.type
 CYPHER;
 
     public function __construct(
@@ -72,12 +77,16 @@ CYPHER;
 
     /**
      * @param  array<int, array{class: string}>  $classRows
-     * @param  array<int, array{abstract: string, abstractKind: string, concrete: string, concreteKind: string, shared: bool}>  $bindingRows
-     * @param  array<int, array{class: string, dependency: string, dependencyKind: string}>  $dependencyRows
-     * @param  array<int, array{class: string, name: string, reason: string}>  $unresolvedRows
+     * @param  array<int, array{abstract: string, abstractKind: string, concrete: string, concreteKind: string, shared: bool, type: string}>  $bindingRows
+     * @param  array<int, array{class: string, dependency: string, dependencyKind: string, type: string}>  $dependencyRows
+     * @param  array<int, array{class: string, name: string, reason: string, type: string}>  $unresolvedRows
      */
     public function write(array $classRows, array $bindingRows, array $dependencyRows, array $unresolvedRows): void
     {
+        $this->validateBindingRows($bindingRows);
+        $this->validateDependencyRows($dependencyRows);
+        $this->validateUnresolvedRows($unresolvedRows);
+
         if ($classRows !== []) {
             $this->connection->run(self::CYPHER_CLASSES, ['rows' => $classRows]);
         }
@@ -103,5 +112,35 @@ CYPHER;
             'dependencies' => self::CYPHER_DEPENDENCIES,
             'unresolved' => self::CYPHER_UNRESOLVED,
         ];
+    }
+
+    /**
+     * @param  array<int, array{abstract: string, abstractKind: string, concrete: string, concreteKind: string, shared: bool, type: string}>  $bindingRows
+     */
+    private function validateBindingRows(array $bindingRows): void
+    {
+        foreach ($bindingRows as $row) {
+            BindsToType::assertAllowed((string) ($row['type'] ?? ''));
+        }
+    }
+
+    /**
+     * @param  array<int, array{class: string, dependency: string, dependencyKind: string, type: string}>  $dependencyRows
+     */
+    private function validateDependencyRows(array $dependencyRows): void
+    {
+        foreach ($dependencyRows as $row) {
+            DependsOnType::assertAllowed((string) ($row['type'] ?? ''));
+        }
+    }
+
+    /**
+     * @param  array<int, array{class: string, name: string, reason: string, type: string}>  $unresolvedRows
+     */
+    private function validateUnresolvedRows(array $unresolvedRows): void
+    {
+        foreach ($unresolvedRows as $row) {
+            DependsOnType::assertAllowed((string) ($row['type'] ?? ''));
+        }
     }
 }

--- a/src/Support/Graph/BindsToType.php
+++ b/src/Support/Graph/BindsToType.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace Neo4j\LaravelBoost\Support\Graph;
+
+use InvalidArgumentException;
+
+enum BindsToType: string
+{
+    case Normal = 'normal';
+    case Singleton = 'singleton';
+
+    public static function assertAllowed(string $value): self
+    {
+        return self::tryFrom($value)
+            ?? throw new InvalidArgumentException("Unknown BINDS_TO type: {$value}");
+    }
+
+    public static function fromShared(bool $shared): self
+    {
+        return $shared ? self::Singleton : self::Normal;
+    }
+}

--- a/src/Support/Graph/DependsOnType.php
+++ b/src/Support/Graph/DependsOnType.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace Neo4j\LaravelBoost\Support\Graph;
+
+use InvalidArgumentException;
+
+enum DependsOnType: string
+{
+    case ConstructorInjection = 'constructor_injection';
+    case MethodInjection = 'method_injection';
+    case Facade = 'facade';
+    case GlobalHelper = 'global_helper';
+    case ServiceLocation = 'service_location';
+    case Instantiation = 'instantiation';
+
+    public static function assertAllowed(string $value): self
+    {
+        return self::tryFrom($value)
+            ?? throw new InvalidArgumentException("Unknown DEPENDS_ON type: {$value}");
+    }
+}

--- a/src/Support/Graph/GraphRelationshipGlossary.php
+++ b/src/Support/Graph/GraphRelationshipGlossary.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace Neo4j\LaravelBoost\Support\Graph;
+
+/**
+ * Agent-facing glossary for container graph relationship types (SOFT-41).
+ */
+final class GraphRelationshipGlossary
+{
+    public const MCP_TOOL_DESCRIPTION_SUFFIX = ' Graph model: dependencies use DEPENDS_ON with type constructor_injection (DI via constructor), method_injection (DI via action/handle method), facade (static facade call), global_helper (cache/auth/view helpers), service_location (app/resolve/App::make), instantiation (direct new). Bindings use BINDS_TO with type normal (transient bind) or singleton (shared instance). Legacy graphs without type are inferred as constructor_injection or normal.';
+}

--- a/src/Support/Graph/RelationshipTypeReader.php
+++ b/src/Support/Graph/RelationshipTypeReader.php
@@ -1,0 +1,50 @@
+<?php
+
+namespace Neo4j\LaravelBoost\Support\Graph;
+
+/**
+ * Resolves relationship type values from Neo4j with backward-compatible inference.
+ */
+final class RelationshipTypeReader
+{
+    /**
+     * @return array{type: string, confidence?: string}
+     */
+    public static function dependsOn(mixed $storedType): array
+    {
+        if ($storedType === null || (string) $storedType === '') {
+            return [
+                'type' => DependsOnType::ConstructorInjection->value,
+                'confidence' => 'inferred',
+            ];
+        }
+
+        return [
+            'type' => DependsOnType::assertAllowed((string) $storedType)->value,
+        ];
+    }
+
+    /**
+     * @return array{type: string, shared: bool, confidence?: string}
+     */
+    public static function bindsTo(mixed $storedType, mixed $legacyShared = null): array
+    {
+        if ($storedType === null || (string) $storedType === '') {
+            $shared = filter_var($legacyShared, FILTER_VALIDATE_BOOLEAN);
+            $type = BindsToType::fromShared($shared);
+
+            return [
+                'type' => $type->value,
+                'shared' => $type === BindsToType::Singleton,
+                'confidence' => 'inferred',
+            ];
+        }
+
+        $type = BindsToType::assertAllowed((string) $storedType);
+
+        return [
+            'type' => $type->value,
+            'shared' => $type === BindsToType::Singleton,
+        ];
+    }
+}

--- a/tests/Integration/ContainerGraphComplexDatasetTest.php
+++ b/tests/Integration/ContainerGraphComplexDatasetTest.php
@@ -64,6 +64,7 @@ class ContainerGraphComplexDatasetTest extends TestCase
         $singletonBinding = $this->graph->findBinding(RedisEventPusher::class);
         $this->assertNotNull($singletonBinding);
         $this->assertTrue($singletonBinding['shared']);
+        $this->assertSame('singleton', $singletonBinding['type']);
 
         $closureBinding = $this->graph->findBinding('reports.analyzer');
         $this->assertNotNull($closureBinding);
@@ -77,6 +78,10 @@ class ContainerGraphComplexDatasetTest extends TestCase
         $this->assertTrue($this->graph->hasDependsOnEdge(Transistor::class, PodcastParser::class));
         $this->assertTrue($this->graph->hasDependsOnEdge(Firewall::class, Logger::class));
         $this->assertTrue($this->graph->hasDependsOnEdge(Firewall::class, Filter::class));
+
+        $transistorDependency = $this->graph->findDependencyRow(Transistor::class, PodcastParser::class);
+        $this->assertNotNull($transistorDependency);
+        $this->assertSame('constructor_injection', $transistorDependency['type']);
     }
 
     public function test_complex_dataset_writes_class_nodes_and_summary_counts(): void

--- a/tests/Integration/ContainerGraphWriterTest.php
+++ b/tests/Integration/ContainerGraphWriterTest.php
@@ -25,6 +25,15 @@ class ContainerGraphWriterTest extends TestCase
 
         $this->assertStringContainsString('row.concreteKind', $bindingsTemplate);
         $this->assertStringContainsString('AbstractType:Abstract', $bindingsTemplate);
+        $this->assertStringContainsString('r.type = row.type', $bindingsTemplate);
+    }
+
+    public function test_dependency_cypher_sets_type_on_depends_on_edges(): void
+    {
+        $writer = new ContainerGraphWriter(new UnusedContainerGraphConnection);
+        $dependenciesTemplate = $writer->cypherTemplates()['dependencies'];
+
+        $this->assertStringContainsString('r.type = row.type', $dependenciesTemplate);
     }
 
     public function test_parse_dsn_extracts_uri_and_credentials(): void

--- a/tests/Integration/GetClassDependencyGraphToolTest.php
+++ b/tests/Integration/GetClassDependencyGraphToolTest.php
@@ -165,6 +165,27 @@ class GetClassDependencyGraphToolTest extends TestCase
         $this->assertContains(PodcastParser::class, $dependencyNames);
     }
 
+    public function test_tool_returns_relationship_type_on_dependencies_and_bindings(): void
+    {
+        $dependencyPayload = $this->callTool([
+            'class' => Transistor::class,
+            'direction' => 'outbound',
+        ]);
+
+        $podcastParserDependency = collect($dependencyPayload['dependencies'] ?? [])
+            ->firstWhere('name', PodcastParser::class);
+
+        $this->assertIsArray($podcastParserDependency);
+        $this->assertSame('constructor_injection', $podcastParserDependency['type']);
+
+        $bindingPayload = $this->callTool([
+            'class' => RedisEventPusher::class,
+            'include_bindings' => true,
+        ]);
+
+        $this->assertSame('singleton', $bindingPayload['binding']['type'] ?? null);
+    }
+
     /**
      * @param  array<string, mixed>  $arguments
      * @return array<string, mixed>

--- a/tests/Integration/Support/InMemoryClassDependencyGraphReader.php
+++ b/tests/Integration/Support/InMemoryClassDependencyGraphReader.php
@@ -4,6 +4,8 @@ namespace Neo4j\LaravelBoost\Tests\Integration\Support;
 
 use Neo4j\LaravelBoost\ClassDependencyGraphReader;
 use Neo4j\LaravelBoost\Support\ContainerGraphConnection;
+use Neo4j\LaravelBoost\Support\Graph\DependsOnType;
+use Neo4j\LaravelBoost\Support\Graph\RelationshipTypeReader;
 use Neo4j\LaravelBoost\Tests\Integration\Support\Stubs\UnusedContainerGraphConnection;
 
 /**
@@ -14,20 +16,20 @@ class InMemoryClassDependencyGraphReader extends ClassDependencyGraphReader
     /** @var array<int, string> */
     private array $classes = [];
 
-    /** @var array<int, array{abstract: string, abstractKind: string, concrete: string, concreteKind: string, shared: bool}> */
+    /** @var array<int, array{abstract: string, abstractKind: string, concrete: string, concreteKind: string, shared: bool, type: string}> */
     private array $bindingRows = [];
 
-    /** @var array<int, array{class: string, dependency: string, dependencyKind: string}> */
+    /** @var array<int, array{class: string, dependency: string, dependencyKind: string, type: string}> */
     private array $dependencyRows = [];
 
-    /** @var array<int, array{class: string, name: string, reason: string}> */
+    /** @var array<int, array{class: string, name: string, reason: string, type: string}> */
     private array $unresolvedRows = [];
 
     /**
      * @param  array<int, array{class: string}>  $classRows
-     * @param  array<int, array{abstract: string, abstractKind: string, concrete: string, concreteKind: string, shared: bool}>  $bindingRows
-     * @param  array<int, array{class: string, dependency: string, dependencyKind: string}>  $dependencyRows
-     * @param  array<int, array{class: string, name: string, reason: string}>  $unresolvedRows
+     * @param  array<int, array{abstract: string, abstractKind: string, concrete: string, concreteKind: string, shared: bool, type: string}>  $bindingRows
+     * @param  array<int, array{class: string, dependency: string, dependencyKind: string, type: string}>  $dependencyRows
+     * @param  array<int, array{class: string, name: string, reason: string, type: string}>  $unresolvedRows
      */
     public static function fromExportRows(
         array $classRows,
@@ -126,31 +128,45 @@ class InMemoryClassDependencyGraphReader extends ClassDependencyGraphReader
     }
 
     /**
-     * @return null|array{abstract: string, concrete: string, shared: bool}
+     * @return null|array{abstract: string, concrete: string, shared: bool, type: string, confidence?: string}
      */
     private function findBindingForClass(string $class): ?array
     {
         foreach ($this->bindingRows as $row) {
             if ($row['abstract'] === $class) {
-                return [
-                    'abstract' => $row['abstract'],
-                    'concrete' => $row['concrete'],
-                    'shared' => $row['shared'],
-                ];
+                return $this->formatBindingRow($row);
             }
         }
 
         foreach ($this->bindingRows as $row) {
             if ($row['concrete'] === $class) {
-                return [
-                    'abstract' => $row['abstract'],
-                    'concrete' => $row['concrete'],
-                    'shared' => $row['shared'],
-                ];
+                return $this->formatBindingRow($row);
             }
         }
 
         return null;
+    }
+
+    /**
+     * @param  array{abstract: string, concrete: string, shared: bool, type: string}  $row
+     * @return array{abstract: string, concrete: string, shared: bool, type: string, confidence?: string}
+     */
+    private function formatBindingRow(array $row): array
+    {
+        $typeMeta = RelationshipTypeReader::bindsTo($row['type'] ?? null, $row['shared'] ?? null);
+
+        $binding = [
+            'abstract' => $row['abstract'],
+            'concrete' => $row['concrete'],
+            'shared' => $typeMeta['shared'],
+            'type' => $typeMeta['type'],
+        ];
+
+        if (isset($typeMeta['confidence'])) {
+            $binding['confidence'] = $typeMeta['confidence'];
+        }
+
+        return $binding;
     }
 
     /**
@@ -172,6 +188,7 @@ class InMemoryClassDependencyGraphReader extends ClassDependencyGraphReader
                 'relationship' => 'DEPENDS_ON',
                 'reason' => $row['reason'],
                 'depth' => 1,
+                ...RelationshipTypeReader::dependsOn($row['type'] ?? null),
             ];
         }
 
@@ -208,6 +225,7 @@ class InMemoryClassDependencyGraphReader extends ClassDependencyGraphReader
                 'kind' => $row['dependencyKind'],
                 'relationship' => 'DEPENDS_ON',
                 'depth' => $currentDepth,
+                ...RelationshipTypeReader::dependsOn($row['type'] ?? null),
             ];
 
             $this->walkDependencies($row['dependency'], $currentDepth + 1, $maxDepth, $entries);
@@ -233,6 +251,7 @@ class InMemoryClassDependencyGraphReader extends ClassDependencyGraphReader
                 'kind' => 'Class',
                 'relationship' => 'DEPENDS_ON',
                 'depth' => $currentDepth,
+                'type' => DependsOnType::ConstructorInjection->value,
             ];
 
             $this->walkDependents($row['class'], $currentDepth + 1, $maxDepth, $entries);

--- a/tests/Integration/Support/RecordingContainerGraphWriter.php
+++ b/tests/Integration/Support/RecordingContainerGraphWriter.php
@@ -18,13 +18,13 @@ class RecordingContainerGraphWriter extends ContainerGraphWriter
     /** @var array<int, array{class: string}> */
     public array $classRows = [];
 
-    /** @var array<int, array{abstract: string, abstractKind: string, concrete: string, concreteKind: string, shared: bool}> */
+    /** @var array<int, array{abstract: string, abstractKind: string, concrete: string, concreteKind: string, shared: bool, type: string}> */
     public array $bindingRows = [];
 
-    /** @var array<int, array{class: string, dependency: string, dependencyKind: string}> */
+    /** @var array<int, array{class: string, dependency: string, dependencyKind: string, type: string}> */
     public array $dependencyRows = [];
 
-    /** @var array<int, array{class: string, name: string, reason: string}> */
+    /** @var array<int, array{class: string, name: string, reason: string, type: string}> */
     public array $unresolvedRows = [];
 
     public function connect(): void
@@ -34,9 +34,9 @@ class RecordingContainerGraphWriter extends ContainerGraphWriter
 
     /**
      * @param  array<int, array{class: string}>  $classRows
-     * @param  array<int, array{abstract: string, abstractKind: string, concrete: string, concreteKind: string, shared: bool}>  $bindingRows
-     * @param  array<int, array{class: string, dependency: string, dependencyKind: string}>  $dependencyRows
-     * @param  array<int, array{class: string, name: string, reason: string}>  $unresolvedRows
+     * @param  array<int, array{abstract: string, abstractKind: string, concrete: string, concreteKind: string, shared: bool, type: string}>  $bindingRows
+     * @param  array<int, array{class: string, dependency: string, dependencyKind: string, type: string}>  $dependencyRows
+     * @param  array<int, array{class: string, name: string, reason: string, type: string}>  $unresolvedRows
      */
     public function write(array $classRows, array $bindingRows, array $dependencyRows, array $unresolvedRows): void
     {
@@ -47,7 +47,7 @@ class RecordingContainerGraphWriter extends ContainerGraphWriter
     }
 
     /**
-     * @return null|array{abstract: string, abstractKind: string, concrete: string, concreteKind: string, shared: bool}
+     * @return null|array{abstract: string, abstractKind: string, concrete: string, concreteKind: string, shared: bool, type: string}
      */
     public function findBinding(string $abstract): ?array
     {
@@ -69,13 +69,21 @@ class RecordingContainerGraphWriter extends ContainerGraphWriter
 
     public function hasDependsOnEdge(string $class, string $dependency): bool
     {
+        return $this->findDependencyRow($class, $dependency) !== null;
+    }
+
+    /**
+     * @return null|array{class: string, dependency: string, dependencyKind: string, type: string}
+     */
+    public function findDependencyRow(string $class, string $dependency): ?array
+    {
         foreach ($this->dependencyRows as $row) {
             if ($row['class'] === $class && $row['dependency'] === $dependency) {
-                return true;
+                return $row;
             }
         }
 
-        return false;
+        return null;
     }
 
     public function hasClassNode(string $class): bool

--- a/tests/Unit/GraphRelationshipTypeTest.php
+++ b/tests/Unit/GraphRelationshipTypeTest.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace Neo4j\LaravelBoost\Tests\Unit;
+
+use Neo4j\LaravelBoost\Support\Graph\BindsToType;
+use Neo4j\LaravelBoost\Support\Graph\DependsOnType;
+use Neo4j\LaravelBoost\Tests\TestCase;
+
+class GraphRelationshipTypeTest extends TestCase
+{
+    public function test_depends_on_type_rejects_unknown_values(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        DependsOnType::assertAllowed('uses_facade');
+    }
+
+    public function test_binds_to_type_maps_shared_flag_to_singleton(): void
+    {
+        $this->assertSame(BindsToType::Singleton, BindsToType::fromShared(true));
+        $this->assertSame(BindsToType::Normal, BindsToType::fromShared(false));
+    }
+}

--- a/tests/Unit/RelationshipTypeReaderTest.php
+++ b/tests/Unit/RelationshipTypeReaderTest.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace Neo4j\LaravelBoost\Tests\Unit;
+
+use Neo4j\LaravelBoost\Support\Graph\RelationshipTypeReader;
+use Neo4j\LaravelBoost\Tests\TestCase;
+
+class RelationshipTypeReaderTest extends TestCase
+{
+    public function test_infers_constructor_injection_when_depends_on_type_missing(): void
+    {
+        $resolved = RelationshipTypeReader::dependsOn(null);
+
+        $this->assertSame('constructor_injection', $resolved['type']);
+        $this->assertSame('inferred', $resolved['confidence']);
+    }
+
+    public function test_infers_normal_binding_from_legacy_shared_false(): void
+    {
+        $resolved = RelationshipTypeReader::bindsTo(null, false);
+
+        $this->assertSame('normal', $resolved['type']);
+        $this->assertFalse($resolved['shared']);
+        $this->assertSame('inferred', $resolved['confidence']);
+    }
+}


### PR DESCRIPTION
Introduces relationship type support in the container dependency graph by adding DEPENDS_ON and BINDS_TO relationship enums. Relationship types are now assigned during graph extraction, persisted on graph edges, and returned through graph readers and tool responses. This PR also includes backward-compatible inference for legacy graphs without relationship types, along with comprehensive tests and documentation updates covering the new relationship model.