### PR TITLE
SOFT-42: Detect service_location hidden deps via static scan in container:graph

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,5 +28,6 @@ coverage/
 # Laravel logs
 storage/logs/*.log
 
-# Local usage notes (do not commit)
+# Local usage / testing notes (do not commit)
 USAGE.local.md
+TESTING.local.md

--- a/README.md
+++ b/README.md
@@ -257,6 +257,8 @@ php artisan container:graph --print-cypher
 
 Dynamic calls such as `app($variable)` are skipped.
 
+**Opt-in only:** when `NEO4J_CONTAINER_GRAPH_STATIC_SCAN_PATHS` is unset or empty, `static_scan_paths` is `[]` and no PHP files are scanned.
+
 Configure scan paths (comma-separated absolute paths):
 
 ```env

--- a/README.md
+++ b/README.md
@@ -247,6 +247,51 @@ php artisan container:graph --dry-run
 php artisan container:graph --print-cypher
 ```
 
+### Static analysis pass (SOFT-43 POC)
+
+`container:graph` can merge **hidden** `DEPENDS_ON` edges discovered by a PHPStan-style scan of configured paths. The POC detects literal **service location** calls:
+
+- `app(Foo::class)`
+- `resolve(Foo::class)`
+- `App::make(Foo::class)`
+
+Dynamic calls such as `app($variable)` are skipped.
+
+Configure scan paths (comma-separated absolute paths):
+
+```env
+NEO4J_CONTAINER_GRAPH_STATIC_SCAN_PATHS=/var/www/html/app/Services
+```
+
+Or in `config/neo4j-boost.php` → `container_graph.static_scan_paths`.
+
+**Output shape** written to Neo4j:
+
+```json
+{
+  "type": "service_location",
+  "via": "app",
+  "file": "/path/OrderProcessor.php",
+  "line": 12,
+  "source": "static"
+}
+```
+
+**POC run target:** package fixtures under `tests/Integration/Fixtures/StaticAnalysis` (enabled in integration tests). Consumer apps opt in via `static_scan_paths`.
+
+**Adding the next hidden type (SOFT-44+):** copy the pattern:
+
+1. Extend `ServiceLocationEdgeFinder` / add a sibling finder for the new pattern.
+2. Register a PHPStan collector rule in `extension.neon` and cover it with `RuleTestCase`.
+3. Merge rows in `ContainerGraphCommand::extractStatic*Rows()` and persist extra edge props in `ContainerGraphWriter`.
+4. Add a fixture PHP file plus an integration test that sets `static_scan_paths`.
+
+Run PHPStan rules against fixtures only:
+
+```bash
+./vendor/bin/phpstan analyse -c phpstan-static-analysis.neon.dist --no-progress
+```
+
 ### Graph model
 
 - `(:Interface:Abstract)-[:BINDS_TO {type}]->(:Class:Abstract)` when the binding key is an interface (`type`: `normal` or `singleton`)

--- a/composer.json
+++ b/composer.json
@@ -37,7 +37,9 @@
     "require-dev": {
         "larastan/larastan": "^3.0",
         "laravel/pint": "^1.18",
+        "nikic/php-parser": "^5.4",
         "orchestra/testbench": "^10.11|^11.0",
+        "phpstan/phpstan": "^2.1",
         "phpunit/phpunit": "^11.0"
     },
     "config": {

--- a/config/neo4j-boost.php
+++ b/config/neo4j-boost.php
@@ -84,5 +84,13 @@ return [
         'default_connection_dsn' => env('NEO4J_DEFAULT_CONNECTION_DSN', ''),
         'username' => env('NEO4J_USER', env('NEO4J_USERNAME', 'neo4j')),
         'password' => env('NEO4J_PASSWORD', ''),
+        /*
+         * Absolute paths scanned for hidden DEPENDS_ON edges (SOFT-43 POC).
+         * Example: [base_path('app/Services')] — package tests set a fixture path.
+         */
+        'static_scan_paths' => array_values(array_filter(array_map(
+            static fn (string $path): string => trim($path),
+            explode(',', (string) env('NEO4J_CONTAINER_GRAPH_STATIC_SCAN_PATHS', '')),
+        ))),
     ],
 ];

--- a/config/neo4j-boost.php
+++ b/config/neo4j-boost.php
@@ -86,7 +86,8 @@ return [
         'password' => env('NEO4J_PASSWORD', ''),
         /*
          * Absolute paths scanned for hidden DEPENDS_ON edges (SOFT-43 POC).
-         * Example: [base_path('app/Services')] — package tests set a fixture path.
+         * When empty (default), no static scan runs — set NEO4J_CONTAINER_GRAPH_STATIC_SCAN_PATHS
+         * to opt in, e.g. base_path('app') or base_path('app/Services').
          */
         'static_scan_paths' => array_values(array_filter(array_map(
             static fn (string $path): string => trim($path),

--- a/extension.neon
+++ b/extension.neon
@@ -1,0 +1,11 @@
+services:
+    -
+        class: Neo4j\LaravelBoost\StaticAnalysis\ServiceLocationNodeResolver
+    -
+        class: Neo4j\LaravelBoost\StaticAnalysis\PhpStan\ServiceLocationFuncCallRule
+        tags:
+            - phpstan.rules.rule
+    -
+        class: Neo4j\LaravelBoost\StaticAnalysis\PhpStan\ServiceLocationStaticCallRule
+        tags:
+            - phpstan.rules.rule

--- a/phpstan-static-analysis-test.neon.dist
+++ b/phpstan-static-analysis-test.neon.dist
@@ -1,0 +1,8 @@
+includes:
+    - extension.neon
+
+parameters:
+    phpVersion: 80200
+    paths: []
+    level: 5
+    treatPhpDocTypesAsCertain: false

--- a/phpstan-static-analysis.neon.dist
+++ b/phpstan-static-analysis.neon.dist
@@ -1,0 +1,11 @@
+includes:
+    - vendor/larastan/larastan/extension.neon
+    - extension.neon
+
+parameters:
+    phpVersion: 80200
+    paths:
+        - tests/Integration/Fixtures/StaticAnalysis
+        - tests/Unit/StaticAnalysis/Fixtures
+    level: 5
+    treatPhpDocTypesAsCertain: false

--- a/src/Console/ContainerGraphCommand.php
+++ b/src/Console/ContainerGraphCommand.php
@@ -5,6 +5,7 @@ namespace Neo4j\LaravelBoost\Console;
 use Closure;
 use Illuminate\Console\Command;
 use Neo4j\LaravelBoost\ContainerGraphWriter;
+use Neo4j\LaravelBoost\StaticAnalysis\ServiceLocationEdgeFinder;
 use Neo4j\LaravelBoost\Support\Graph\BindsToType;
 use Neo4j\LaravelBoost\Support\Graph\DependsOnType;
 use RecursiveDirectoryIterator;
@@ -27,6 +28,12 @@ class ContainerGraphCommand extends Command
         [$bindingRows, $concreteClasses] = $this->extractBindingRows();
         $concreteClasses = $this->mergeClassLists($concreteClasses, $this->extractCustomClassNames());
         [$dependencyRows, $unresolvedRows] = $this->extractDependencyRows($concreteClasses);
+        $staticDependencyRows = $this->extractStaticServiceLocationRows();
+        $dependencyRows = $this->uniqueRows(array_merge($dependencyRows, $staticDependencyRows));
+        $concreteClasses = $this->mergeClassLists(
+            $concreteClasses,
+            $this->classNamesFromDependencyRows($staticDependencyRows),
+        );
         $classRows = array_map(
             static fn (string $className): array => ['class' => $className],
             $concreteClasses
@@ -37,6 +44,7 @@ class ContainerGraphCommand extends Command
         $this->line('- Concrete classes inspected: '.count($concreteClasses));
         $this->line('- Class nodes: '.count($classRows));
         $this->line('- Dependency edges: '.count($dependencyRows));
+        $this->line('- Static service_location edges: '.count($staticDependencyRows));
         $this->line('- Unresolved dependencies: '.count($unresolvedRows));
 
         if ($this->option('print-cypher')) {
@@ -185,7 +193,7 @@ class ContainerGraphCommand extends Command
 
     /**
      * @param  array<int, string>  $classes
-     * @return array{0: array<int, array{class: string, dependency: string, dependencyKind: string, type: string}>, 1: array<int, array{class: string, name: string, reason: string, type: string}>}
+     * @return array{0: array<int, array{class: string, dependency: string, dependencyKind: string, type: string, source: string, via: string, file: string, line: int}>, 1: array<int, array{class: string, name: string, reason: string, type: string}>}
      */
     private function extractDependencyRows(array $classes): array
     {
@@ -223,12 +231,60 @@ class ContainerGraphCommand extends Command
                         'dependency' => $name,
                         'dependencyKind' => $kind,
                         'type' => DependsOnType::ConstructorInjection->value,
+                        ...$this->emptyStaticMetadata(),
                     ];
                 }
             }
         }
 
         return [$this->uniqueRows($dependencyRows), $this->uniqueRows($unresolvedRows)];
+    }
+
+    /**
+     * @return array<int, array{class: string, dependency: string, dependencyKind: string, type: string, source: string, via: string, file: string, line: int}>
+     */
+    private function extractStaticServiceLocationRows(): array
+    {
+        $paths = config('neo4j-boost.container_graph.static_scan_paths', []);
+        if (! is_array($paths) || $paths === []) {
+            return [];
+        }
+
+        $rows = [];
+        foreach ((new ServiceLocationEdgeFinder)->scanPaths($paths) as $edge) {
+            $rows[] = $edge->toDependencyRow();
+        }
+
+        return $this->uniqueRows($rows);
+    }
+
+    /**
+     * @param  array<int, array{class: string, dependency: string}>  $rows
+     * @return array<int, string>
+     */
+    private function classNamesFromDependencyRows(array $rows): array
+    {
+        $classes = [];
+
+        foreach ($rows as $row) {
+            $classes[] = $row['class'];
+            $classes[] = $row['dependency'];
+        }
+
+        return array_values(array_unique($classes));
+    }
+
+    /**
+     * @return array{source: string, via: string, file: string, line: int}
+     */
+    private function emptyStaticMetadata(): array
+    {
+        return [
+            'source' => '',
+            'via' => '',
+            'file' => '',
+            'line' => 0,
+        ];
     }
 
     /**

--- a/src/Console/ContainerGraphCommand.php
+++ b/src/Console/ContainerGraphCommand.php
@@ -23,6 +23,12 @@ class ContainerGraphCommand extends Command
 
     protected $description = 'Export Laravel container wiring into Neo4j for dependency debugging';
 
+    public function __construct(
+        private ServiceLocationEdgeFinder $serviceLocationEdgeFinder,
+    ) {
+        parent::__construct();
+    }
+
     public function handle(ContainerGraphWriter $writer): int
     {
         [$bindingRows, $concreteClasses] = $this->extractBindingRows();
@@ -251,7 +257,7 @@ class ContainerGraphCommand extends Command
         }
 
         $rows = [];
-        foreach ((new ServiceLocationEdgeFinder)->scanPaths($paths) as $edge) {
+        foreach ($this->serviceLocationEdgeFinder->scanPaths($paths) as $edge) {
             $rows[] = $edge->toDependencyRow();
         }
 

--- a/src/ContainerGraphWriter.php
+++ b/src/ContainerGraphWriter.php
@@ -2,6 +2,7 @@
 
 namespace Neo4j\LaravelBoost;
 
+use Neo4j\LaravelBoost\StaticAnalysis\DependencyEdgeSource;
 use Neo4j\LaravelBoost\Support\ContainerGraphConnection;
 use Neo4j\LaravelBoost\Support\Graph\BindsToType;
 use Neo4j\LaravelBoost\Support\Graph\DependsOnType;
@@ -48,12 +49,20 @@ MERGE (c:Class:Abstract {name: row.class})
 FOREACH (_ IN CASE WHEN row.dependencyKind = 'Interface' THEN [1] ELSE [] END |
   MERGE (d:Interface:Abstract {name: row.dependency})
   MERGE (c)-[r:DEPENDS_ON]->(d)
-  SET r.type = row.type
+  SET r.type = row.type,
+      r.source = row.source,
+      r.via = row.via,
+      r.file = row.file,
+      r.line = row.line
 )
 FOREACH (_ IN CASE WHEN row.dependencyKind <> 'Interface' THEN [1] ELSE [] END |
   MERGE (d:Class:Abstract {name: row.dependency})
   MERGE (c)-[r:DEPENDS_ON]->(d)
-  SET r.type = row.type
+  SET r.type = row.type,
+      r.source = row.source,
+      r.via = row.via,
+      r.file = row.file,
+      r.line = row.line
 )
 CYPHER;
 
@@ -78,7 +87,7 @@ CYPHER;
     /**
      * @param  array<int, array{class: string}>  $classRows
      * @param  array<int, array{abstract: string, abstractKind: string, concrete: string, concreteKind: string, shared: bool, type: string}>  $bindingRows
-     * @param  array<int, array{class: string, dependency: string, dependencyKind: string, type: string}>  $dependencyRows
+     * @param  array<int, array{class: string, dependency: string, dependencyKind: string, type: string, source: string, via: string, file: string, line: int}>  $dependencyRows
      * @param  array<int, array{class: string, name: string, reason: string, type: string}>  $unresolvedRows
      */
     public function write(array $classRows, array $bindingRows, array $dependencyRows, array $unresolvedRows): void
@@ -125,12 +134,33 @@ CYPHER;
     }
 
     /**
-     * @param  array<int, array{class: string, dependency: string, dependencyKind: string, type: string}>  $dependencyRows
+     * @param  array<int, array{class: string, dependency: string, dependencyKind: string, type: string, source: string, via: string, file: string, line: int}>  $dependencyRows
      */
     private function validateDependencyRows(array $dependencyRows): void
     {
         foreach ($dependencyRows as $row) {
             DependsOnType::assertAllowed((string) ($row['type'] ?? ''));
+            $this->assertDependencyMetadata($row);
+        }
+    }
+
+    /**
+     * @param  array<string, mixed>  $row
+     */
+    private function assertDependencyMetadata(array $row): void
+    {
+        foreach (['source', 'via', 'file'] as $key) {
+            if (! array_key_exists($key, $row) || ! is_string($row[$key])) {
+                throw new \InvalidArgumentException("Dependency row is missing string {$key}");
+            }
+        }
+
+        if (! array_key_exists('line', $row) || ! is_int($row['line'])) {
+            throw new \InvalidArgumentException('Dependency row is missing integer line');
+        }
+
+        if ($row['source'] === DependencyEdgeSource::Static->value && $row['type'] !== DependsOnType::ServiceLocation->value) {
+            throw new \InvalidArgumentException('Static analysis edges must use service_location type');
         }
     }
 

--- a/src/Neo4jBoostServiceProvider.php
+++ b/src/Neo4jBoostServiceProvider.php
@@ -17,6 +17,7 @@ use Neo4j\LaravelBoost\Console\StartNeo4jCommand;
 use Neo4j\LaravelBoost\Console\TestStdioCommand;
 use Neo4j\LaravelBoost\Contracts\BoltExecutorInterface;
 use Neo4j\LaravelBoost\Contracts\Neo4jMcpClientInterface;
+use Neo4j\LaravelBoost\StaticAnalysis\ServiceLocationEdgeFinder;
 use Neo4j\LaravelBoost\Support\ContainerGraphConnection;
 use Neo4j\LaravelBoost\Support\Neo4jBoltClient;
 
@@ -40,6 +41,7 @@ class Neo4jBoostServiceProvider extends ServiceProvider
         });
         $this->app->singleton(ContainerGraphConnection::class);
         $this->app->singleton(ClassDependencyGraphReader::class);
+        $this->app->singleton(ServiceLocationEdgeFinder::class);
     }
 
     public function boot(): void

--- a/src/StaticAnalysis/DependencyEdgeSource.php
+++ b/src/StaticAnalysis/DependencyEdgeSource.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace Neo4j\LaravelBoost\StaticAnalysis;
+
+/**
+ * Provenance for edges discovered by PHPStan static analysis (SOFT-43 POC).
+ */
+enum DependencyEdgeSource: string
+{
+    case Static = 'static';
+}

--- a/src/StaticAnalysis/PhpStan/ServiceLocationFuncCallRule.php
+++ b/src/StaticAnalysis/PhpStan/ServiceLocationFuncCallRule.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace Neo4j\LaravelBoost\StaticAnalysis\PhpStan;
+
+use Neo4j\LaravelBoost\StaticAnalysis\ServiceLocationNodeResolver;
+use Neo4j\LaravelBoost\StaticAnalysis\StaticAnalysisCollector;
+use PhpParser\Node;
+use PhpParser\Node\Expr\FuncCall;
+use PHPStan\Analyser\Scope;
+use PHPStan\Rules\Rule;
+
+/**
+ * @implements Rule<FuncCall>
+ */
+final class ServiceLocationFuncCallRule implements Rule
+{
+    public function __construct(
+        private ServiceLocationNodeResolver $resolver = new ServiceLocationNodeResolver,
+    ) {}
+
+    public function getNodeType(): string
+    {
+        return FuncCall::class;
+    }
+
+    public function processNode(Node $node, Scope $scope): array
+    {
+        if (! $node instanceof FuncCall) {
+            return [];
+        }
+
+        $edge = $this->resolver->fromFuncCall($node, $scope);
+        if ($edge !== null) {
+            StaticAnalysisCollector::addServiceLocation($edge);
+        }
+
+        return [];
+    }
+}

--- a/src/StaticAnalysis/PhpStan/ServiceLocationFuncCallRule.php
+++ b/src/StaticAnalysis/PhpStan/ServiceLocationFuncCallRule.php
@@ -15,7 +15,7 @@ use PHPStan\Rules\Rule;
 final class ServiceLocationFuncCallRule implements Rule
 {
     public function __construct(
-        private ServiceLocationNodeResolver $resolver = new ServiceLocationNodeResolver,
+        private ServiceLocationNodeResolver $resolver,
     ) {}
 
     public function getNodeType(): string

--- a/src/StaticAnalysis/PhpStan/ServiceLocationStaticCallRule.php
+++ b/src/StaticAnalysis/PhpStan/ServiceLocationStaticCallRule.php
@@ -15,7 +15,7 @@ use PHPStan\Rules\Rule;
 final class ServiceLocationStaticCallRule implements Rule
 {
     public function __construct(
-        private ServiceLocationNodeResolver $resolver = new ServiceLocationNodeResolver,
+        private ServiceLocationNodeResolver $resolver,
     ) {}
 
     public function getNodeType(): string

--- a/src/StaticAnalysis/PhpStan/ServiceLocationStaticCallRule.php
+++ b/src/StaticAnalysis/PhpStan/ServiceLocationStaticCallRule.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace Neo4j\LaravelBoost\StaticAnalysis\PhpStan;
+
+use Neo4j\LaravelBoost\StaticAnalysis\ServiceLocationNodeResolver;
+use Neo4j\LaravelBoost\StaticAnalysis\StaticAnalysisCollector;
+use PhpParser\Node;
+use PhpParser\Node\Expr\StaticCall;
+use PHPStan\Analyser\Scope;
+use PHPStan\Rules\Rule;
+
+/**
+ * @implements Rule<StaticCall>
+ */
+final class ServiceLocationStaticCallRule implements Rule
+{
+    public function __construct(
+        private ServiceLocationNodeResolver $resolver = new ServiceLocationNodeResolver,
+    ) {}
+
+    public function getNodeType(): string
+    {
+        return StaticCall::class;
+    }
+
+    public function processNode(Node $node, Scope $scope): array
+    {
+        if (! $node instanceof StaticCall) {
+            return [];
+        }
+
+        $edge = $this->resolver->fromStaticCall($node, $scope);
+        if ($edge !== null) {
+            StaticAnalysisCollector::addServiceLocation($edge);
+        }
+
+        return [];
+    }
+}

--- a/src/StaticAnalysis/ServiceLocationEdge.php
+++ b/src/StaticAnalysis/ServiceLocationEdge.php
@@ -1,0 +1,43 @@
+<?php
+
+namespace Neo4j\LaravelBoost\StaticAnalysis;
+
+/**
+ * A service-locator dependency discovered in PHP source (app / resolve / App::make).
+ */
+final readonly class ServiceLocationEdge
+{
+    public function __construct(
+        public string $class,
+        public string $dependency,
+        public string $via,
+        public string $file,
+        public int $line,
+    ) {}
+
+    /**
+     * @return array{
+     *     class: string,
+     *     dependency: string,
+     *     dependencyKind: string,
+     *     type: string,
+     *     via: string,
+     *     file: string,
+     *     line: int,
+     *     source: string
+     * }
+     */
+    public function toDependencyRow(): array
+    {
+        return [
+            'class' => $this->class,
+            'dependency' => $this->dependency,
+            'dependencyKind' => interface_exists($this->dependency) ? 'Interface' : 'Class',
+            'type' => 'service_location',
+            'via' => $this->via,
+            'file' => $this->file,
+            'line' => $this->line,
+            'source' => DependencyEdgeSource::Static->value,
+        ];
+    }
+}

--- a/src/StaticAnalysis/ServiceLocationEdgeFinder.php
+++ b/src/StaticAnalysis/ServiceLocationEdgeFinder.php
@@ -1,0 +1,117 @@
+<?php
+
+namespace Neo4j\LaravelBoost\StaticAnalysis;
+
+use PhpParser\NodeTraverser;
+use PhpParser\ParserFactory;
+use PhpParser\PhpVersion;
+use RecursiveDirectoryIterator;
+use RecursiveIteratorIterator;
+use SplFileInfo;
+
+/**
+ * Finds literal service-locator calls in PHP files (SOFT-43 POC).
+ */
+final class ServiceLocationEdgeFinder
+{
+    /**
+     * @param  array<int, string>  $paths
+     * @return list<ServiceLocationEdge>
+     */
+    public function scanPaths(array $paths): array
+    {
+        $edges = [];
+
+        foreach ($paths as $path) {
+            if (! is_string($path) || $path === '') {
+                continue;
+            }
+
+            if (is_file($path) && str_ends_with($path, '.php')) {
+                $edges = array_merge($edges, $this->scanFile($path));
+
+                continue;
+            }
+
+            if (! is_dir($path)) {
+                continue;
+            }
+
+            $iterator = new RecursiveIteratorIterator(
+                new RecursiveDirectoryIterator($path, RecursiveDirectoryIterator::SKIP_DOTS)
+            );
+
+            foreach ($iterator as $file) {
+                if (! $file instanceof SplFileInfo || ! $file->isFile() || $file->getExtension() !== 'php') {
+                    continue;
+                }
+
+                $edges = array_merge($edges, $this->scanFile($file->getPathname()));
+            }
+        }
+
+        return $this->uniqueEdges($edges);
+    }
+
+    /**
+     * @return list<ServiceLocationEdge>
+     */
+    public function scanSource(string $source, string $file = 'inline.php'): array
+    {
+        $parser = (new ParserFactory)->createForVersion(PhpVersion::fromString('8.2'));
+        $ast = $parser->parse($source);
+
+        if ($ast === null) {
+            return [];
+        }
+
+        $visitor = new ServiceLocationFileVisitor($file);
+        $traverser = new NodeTraverser;
+        $traverser->addVisitor($visitor);
+        $traverser->traverse($ast);
+
+        return $visitor->edges();
+    }
+
+    /**
+     * @return list<ServiceLocationEdge>
+     */
+    private function scanFile(string $file): array
+    {
+        $contents = @file_get_contents($file);
+        if ($contents === false) {
+            return [];
+        }
+
+        return $this->scanSource($contents, $file);
+    }
+
+    /**
+     * @param  list<ServiceLocationEdge>  $edges
+     * @return list<ServiceLocationEdge>
+     */
+    private function uniqueEdges(array $edges): array
+    {
+        $seen = [];
+        $unique = [];
+
+        foreach ($edges as $edge) {
+            $key = json_encode([
+                $edge->class,
+                $edge->dependency,
+                $edge->via,
+                $edge->file,
+                $edge->line,
+            ]);
+
+            if ($key === false || isset($seen[$key])) {
+                continue;
+            }
+
+            $seen[$key] = true;
+            $unique[] = $edge;
+        }
+
+        return $unique;
+    }
+}

--- a/src/StaticAnalysis/ServiceLocationFileVisitor.php
+++ b/src/StaticAnalysis/ServiceLocationFileVisitor.php
@@ -1,0 +1,168 @@
+<?php
+
+namespace Neo4j\LaravelBoost\StaticAnalysis;
+
+use PhpParser\Node;
+use PhpParser\Node\Expr\ClassConstFetch;
+use PhpParser\Node\Expr\FuncCall;
+use PhpParser\Node\Expr\StaticCall;
+use PhpParser\Node\Name;
+use PhpParser\Node\Scalar\String_;
+use PhpParser\NodeVisitorAbstract;
+
+final class ServiceLocationFileVisitor extends NodeVisitorAbstract
+{
+    private string $namespace = '';
+
+    private ?string $currentClass = null;
+
+    /** @var list<ServiceLocationEdge> */
+    private array $edges = [];
+
+    public function __construct(
+        private string $file,
+    ) {}
+
+    /**
+     * @return list<ServiceLocationEdge>
+     */
+    public function edges(): array
+    {
+        return $this->edges;
+    }
+
+    public function enterNode(Node $node): ?int
+    {
+        if ($node instanceof Node\Stmt\Namespace_) {
+            $this->namespace = $node->name instanceof Name ? $node->name->toString() : '';
+
+            return null;
+        }
+
+        if ($node instanceof Node\Stmt\Class_) {
+            $this->currentClass = $this->qualifyName($node->name?->toString() ?? '');
+
+            return null;
+        }
+
+        if ($this->currentClass === null) {
+            return null;
+        }
+
+        if ($node instanceof FuncCall) {
+            $edge = $this->edgeFromFunctionCall($node);
+            if ($edge !== null) {
+                $this->edges[] = $edge;
+            }
+        }
+
+        if ($node instanceof StaticCall) {
+            $edge = $this->edgeFromStaticCall($node);
+            if ($edge !== null) {
+                $this->edges[] = $edge;
+            }
+        }
+
+        return null;
+    }
+
+    public function leaveNode(Node $node): ?Node
+    {
+        if ($node instanceof Node\Stmt\Class_) {
+            $this->currentClass = null;
+        }
+
+        return null;
+    }
+
+    private function edgeFromFunctionCall(FuncCall $node): ?ServiceLocationEdge
+    {
+        $via = $this->functionVia($node);
+        if ($via === null) {
+            return null;
+        }
+
+        return $this->buildEdge($node, $via);
+    }
+
+    private function edgeFromStaticCall(StaticCall $node): ?ServiceLocationEdge
+    {
+        if (! $node->name instanceof Node\Identifier || $node->name->toString() !== 'make') {
+            return null;
+        }
+
+        if (! $this->isAppFacadeCall($node->class)) {
+            return null;
+        }
+
+        return $this->buildEdge($node, 'App::make');
+    }
+
+    private function buildEdge(FuncCall|StaticCall $node, string $via): ?ServiceLocationEdge
+    {
+        $dependency = $this->resolveDependencyName($node->args[0]->value ?? null);
+        if ($dependency === null || $this->currentClass === null) {
+            return null;
+        }
+
+        return new ServiceLocationEdge(
+            class: $this->currentClass,
+            dependency: $dependency,
+            via: $via,
+            file: $this->file,
+            line: $node->getStartLine(),
+        );
+    }
+
+    private function functionVia(FuncCall $node): ?string
+    {
+        if (! $node->name instanceof Name) {
+            return null;
+        }
+
+        return match ($node->name->toString()) {
+            'app' => 'app',
+            'resolve' => 'resolve',
+            default => null,
+        };
+    }
+
+    private function isAppFacadeCall(Node $class): bool
+    {
+        if (! $class instanceof Name) {
+            return false;
+        }
+
+        $name = $class->toString();
+
+        return $name === 'App' || $name === 'Illuminate\\Support\\Facades\\App';
+    }
+
+    private function resolveDependencyName(?Node\Expr $argument): ?string
+    {
+        if ($argument instanceof ClassConstFetch && $argument->class instanceof Name) {
+            return $this->qualifyName(ltrim($argument->class->toString(), '\\'));
+        }
+
+        if ($argument instanceof String_) {
+            $value = $argument->value;
+
+            return $value !== '' ? ltrim($value, '\\') : null;
+        }
+
+        return null;
+    }
+
+    private function qualifyName(string $shortName): string
+    {
+        if ($shortName === '') {
+            return $this->namespace;
+        }
+
+        if (str_contains($shortName, '\\')) {
+            return ltrim($shortName, '\\');
+        }
+
+        return $this->namespace === '' ? $shortName : $this->namespace.'\\'.$shortName;
+    }
+}

--- a/src/StaticAnalysis/ServiceLocationNodeResolver.php
+++ b/src/StaticAnalysis/ServiceLocationNodeResolver.php
@@ -1,0 +1,113 @@
+<?php
+
+namespace Neo4j\LaravelBoost\StaticAnalysis;
+
+use PhpParser\Node;
+use PhpParser\Node\Expr\ClassConstFetch;
+use PhpParser\Node\Expr\FuncCall;
+use PhpParser\Node\Expr\StaticCall;
+use PhpParser\Node\Name;
+use PhpParser\Node\Scalar\String_;
+use PHPStan\Analyser\Scope;
+
+final class ServiceLocationNodeResolver
+{
+    public function fromFuncCall(FuncCall $node, Scope $scope): ?ServiceLocationEdge
+    {
+        $via = $this->functionVia($node);
+        if ($via === null) {
+            return null;
+        }
+
+        return $this->buildEdge($node, $scope, $via);
+    }
+
+    public function fromStaticCall(StaticCall $node, Scope $scope): ?ServiceLocationEdge
+    {
+        if (! $node->name instanceof Node\Identifier || $node->name->toString() !== 'make') {
+            return null;
+        }
+
+        if (! $this->isAppFacadeCall($node->class)) {
+            return null;
+        }
+
+        return $this->buildEdge($node, $scope, 'App::make');
+    }
+
+    private function buildEdge(Node $node, Scope $scope, string $via): ?ServiceLocationEdge
+    {
+        $classReflection = $scope->getClassReflection();
+        $file = $scope->getFile();
+
+        if ($classReflection === null) {
+            return null;
+        }
+
+        $args = $node instanceof FuncCall || $node instanceof StaticCall ? $node->args : [];
+        $firstArg = $args[0]->value ?? null;
+        $dependency = $this->resolveDependencyName($firstArg, $scope);
+
+        if ($dependency === null) {
+            return null;
+        }
+
+        return new ServiceLocationEdge(
+            class: $classReflection->getName(),
+            dependency: $dependency,
+            via: $via,
+            file: $file,
+            line: $node->getStartLine(),
+        );
+    }
+
+    private function functionVia(FuncCall $node): ?string
+    {
+        if (! $node->name instanceof Name) {
+            return null;
+        }
+
+        return match ($node->name->toString()) {
+            'app' => 'app',
+            'resolve' => 'resolve',
+            default => null,
+        };
+    }
+
+    private function isAppFacadeCall(Node $class): bool
+    {
+        if (! $class instanceof Name) {
+            return false;
+        }
+
+        $name = $class->toString();
+
+        return $name === 'App' || $name === 'Illuminate\\Support\\Facades\\App';
+    }
+
+    private function resolveDependencyName(?Node\Expr $argument, Scope $scope): ?string
+    {
+        if ($argument instanceof ClassConstFetch && $argument->class instanceof Name) {
+            return $this->resolveClassName($argument->class, $scope);
+        }
+
+        if ($argument instanceof String_) {
+            $value = $argument->value;
+
+            return $value !== '' ? ltrim($value, '\\') : null;
+        }
+
+        return null;
+    }
+
+    private function resolveClassName(Name $name, Scope $scope): string
+    {
+        if ($name->isFullyQualified()) {
+            return ltrim($name->toString(), '\\');
+        }
+
+        $resolved = $scope->resolveName($name);
+
+        return ltrim($resolved, '\\');
+    }
+}

--- a/src/StaticAnalysis/StaticAnalysisCollector.php
+++ b/src/StaticAnalysis/StaticAnalysisCollector.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace Neo4j\LaravelBoost\StaticAnalysis;
+
+/**
+ * In-memory store for edges collected during a PHPStan run (SOFT-43 POC).
+ */
+final class StaticAnalysisCollector
+{
+    /** @var list<ServiceLocationEdge> */
+    private static array $serviceLocationEdges = [];
+
+    public static function addServiceLocation(ServiceLocationEdge $edge): void
+    {
+        self::$serviceLocationEdges[] = $edge;
+    }
+
+    /**
+     * @return list<ServiceLocationEdge>
+     */
+    public static function serviceLocationEdges(): array
+    {
+        return self::$serviceLocationEdges;
+    }
+
+    public static function reset(): void
+    {
+        self::$serviceLocationEdges = [];
+    }
+}

--- a/tests/Integration/ContainerGraphStaticAnalysisTest.php
+++ b/tests/Integration/ContainerGraphStaticAnalysisTest.php
@@ -1,0 +1,55 @@
+<?php
+
+namespace Neo4j\LaravelBoost\Tests\Integration;
+
+use Neo4j\LaravelBoost\ContainerGraphWriter;
+use Neo4j\LaravelBoost\Tests\Integration\Fixtures\StaticAnalysis\Services\OrderProcessor;
+use Neo4j\LaravelBoost\Tests\Integration\Fixtures\StaticAnalysis\Services\PaymentGateway;
+use Neo4j\LaravelBoost\Tests\Integration\Support\RecordingContainerGraphWriter;
+use Neo4j\LaravelBoost\Tests\TestCase;
+
+class ContainerGraphStaticAnalysisTest extends TestCase
+{
+    private RecordingContainerGraphWriter $graph;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        config([
+            'neo4j-boost.container_graph.static_scan_paths' => [
+                dirname(__DIR__).'/Integration/Fixtures/StaticAnalysis',
+            ],
+        ]);
+
+        $this->graph = new RecordingContainerGraphWriter;
+        $this->app->instance(ContainerGraphWriter::class, $this->graph);
+    }
+
+    public function test_container_graph_exports_service_location_edges_from_static_scan(): void
+    {
+        $this->artisan('container:graph')
+            ->expectsOutputToContain('Static service_location edges: 3')
+            ->expectsOutputToContain('Container graph written to Neo4j successfully.')
+            ->assertExitCode(0);
+
+        $edge = $this->graph->findDependencyRow(OrderProcessor::class, PaymentGateway::class);
+        $this->assertNotNull($edge);
+        $this->assertSame('service_location', $edge['type']);
+        $this->assertSame('static', $edge['source']);
+        $this->assertContains($edge['via'], ['app', 'resolve', 'App::make']);
+        $this->assertStringContainsString('OrderProcessor.php', $edge['file']);
+        $this->assertGreaterThan(0, $edge['line']);
+    }
+
+    public function test_static_scan_paths_can_be_disabled(): void
+    {
+        config(['neo4j-boost.container_graph.static_scan_paths' => []]);
+
+        $this->artisan('container:graph')
+            ->expectsOutputToContain('Static service_location edges: 0')
+            ->assertExitCode(0);
+
+        $this->assertNull($this->graph->findDependencyRow(OrderProcessor::class, PaymentGateway::class));
+    }
+}

--- a/tests/Integration/ContainerGraphWriterTest.php
+++ b/tests/Integration/ContainerGraphWriterTest.php
@@ -34,6 +34,10 @@ class ContainerGraphWriterTest extends TestCase
         $dependenciesTemplate = $writer->cypherTemplates()['dependencies'];
 
         $this->assertStringContainsString('r.type = row.type', $dependenciesTemplate);
+        $this->assertStringContainsString('r.source = row.source', $dependenciesTemplate);
+        $this->assertStringContainsString('r.via = row.via', $dependenciesTemplate);
+        $this->assertStringContainsString('r.file = row.file', $dependenciesTemplate);
+        $this->assertStringContainsString('r.line = row.line', $dependenciesTemplate);
     }
 
     public function test_parse_dsn_extracts_uri_and_credentials(): void

--- a/tests/Integration/Fixtures/StaticAnalysis/Services/OrderProcessor.php
+++ b/tests/Integration/Fixtures/StaticAnalysis/Services/OrderProcessor.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace Neo4j\LaravelBoost\Tests\Integration\Fixtures\StaticAnalysis\Services;
+
+use Illuminate\Support\Facades\App;
+
+final class OrderProcessor
+{
+    public function processWithApp(): void
+    {
+        app(PaymentGateway::class);
+    }
+
+    public function processWithResolve(): void
+    {
+        resolve(PaymentGateway::class);
+    }
+
+    public function processWithFacadeMake(): void
+    {
+        App::make(PaymentGateway::class);
+    }
+
+    public function skipDynamicLocator(string $abstract): void
+    {
+        app($abstract);
+        resolve($abstract);
+        App::make($abstract);
+    }
+}

--- a/tests/Integration/Fixtures/StaticAnalysis/Services/PaymentGateway.php
+++ b/tests/Integration/Fixtures/StaticAnalysis/Services/PaymentGateway.php
@@ -1,0 +1,8 @@
+<?php
+
+namespace Neo4j\LaravelBoost\Tests\Integration\Fixtures\StaticAnalysis\Services;
+
+final class PaymentGateway
+{
+    public function charge(): void {}
+}

--- a/tests/Unit/StaticAnalysis/Fixtures/DynamicServiceLocator.php
+++ b/tests/Unit/StaticAnalysis/Fixtures/DynamicServiceLocator.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace Neo4j\LaravelBoost\Tests\Unit\StaticAnalysis\Fixtures;
+
+use Illuminate\Support\Facades\App;
+
+final class DynamicServiceLocator
+{
+    public function run(string $abstract): void
+    {
+        app($abstract);
+        resolve($abstract);
+        App::make($abstract);
+    }
+}

--- a/tests/Unit/StaticAnalysis/ServiceLocationCollectorRuleTest.php
+++ b/tests/Unit/StaticAnalysis/ServiceLocationCollectorRuleTest.php
@@ -1,0 +1,60 @@
+<?php
+
+namespace Neo4j\LaravelBoost\Tests\Unit\StaticAnalysis;
+
+use Neo4j\LaravelBoost\StaticAnalysis\PhpStan\ServiceLocationFuncCallRule;
+use Neo4j\LaravelBoost\StaticAnalysis\ServiceLocationNodeResolver;
+use Neo4j\LaravelBoost\StaticAnalysis\StaticAnalysisCollector;
+use PHPStan\Rules\Rule;
+use PHPStan\Testing\RuleTestCase;
+
+/**
+ * @extends RuleTestCase<ServiceLocationFuncCallRule>
+ */
+class ServiceLocationCollectorRuleTest extends RuleTestCase
+{
+    protected function getRule(): Rule
+    {
+        return new ServiceLocationFuncCallRule(new ServiceLocationNodeResolver);
+    }
+
+    protected function tearDown(): void
+    {
+        StaticAnalysisCollector::reset();
+
+        parent::tearDown();
+    }
+
+    public function test_collector_records_literal_app_call(): void
+    {
+        StaticAnalysisCollector::reset();
+
+        $this->analyse(
+            [dirname(__DIR__, 2).'/Integration/Fixtures/StaticAnalysis/Services/OrderProcessor.php'],
+            [],
+        );
+
+        $edges = StaticAnalysisCollector::serviceLocationEdges();
+        $this->assertNotEmpty($edges);
+        $this->assertContains('app', array_map(static fn ($edge): string => $edge->via, $edges));
+    }
+
+    public function test_collector_ignores_dynamic_app_call(): void
+    {
+        StaticAnalysisCollector::reset();
+
+        $this->analyse(
+            [__DIR__.'/Fixtures/DynamicServiceLocator.php'],
+            [],
+        );
+
+        $this->assertSame([], StaticAnalysisCollector::serviceLocationEdges());
+    }
+
+    public static function getAdditionalConfigFiles(): array
+    {
+        return [
+            dirname(__DIR__, 3).'/phpstan-static-analysis-test.neon.dist',
+        ];
+    }
+}

--- a/tests/Unit/StaticAnalysis/ServiceLocationEdgeFinderTest.php
+++ b/tests/Unit/StaticAnalysis/ServiceLocationEdgeFinderTest.php
@@ -10,7 +10,7 @@ class ServiceLocationEdgeFinderTest extends TestCase
     public function test_finds_literal_app_resolve_and_app_make_calls(): void
     {
         $fixtureDir = dirname(__DIR__, 2).'/Integration/Fixtures/StaticAnalysis';
-        $edges = (new ServiceLocationEdgeFinder)->scanPaths([$fixtureDir]);
+        $edges = $this->app->make(ServiceLocationEdgeFinder::class)->scanPaths([$fixtureDir]);
 
         $this->assertCount(3, $edges);
 
@@ -52,7 +52,7 @@ class Worker
 }
 PHP;
 
-        $edges = (new ServiceLocationEdgeFinder)->scanSource($source);
+        $edges = $this->app->make(ServiceLocationEdgeFinder::class)->scanSource($source);
 
         $this->assertSame([], $edges);
     }

--- a/tests/Unit/StaticAnalysis/ServiceLocationEdgeFinderTest.php
+++ b/tests/Unit/StaticAnalysis/ServiceLocationEdgeFinderTest.php
@@ -1,0 +1,59 @@
+<?php
+
+namespace Neo4j\LaravelBoost\Tests\Unit\StaticAnalysis;
+
+use Neo4j\LaravelBoost\StaticAnalysis\ServiceLocationEdgeFinder;
+use Neo4j\LaravelBoost\Tests\TestCase;
+
+class ServiceLocationEdgeFinderTest extends TestCase
+{
+    public function test_finds_literal_app_resolve_and_app_make_calls(): void
+    {
+        $fixtureDir = dirname(__DIR__, 2).'/Integration/Fixtures/StaticAnalysis';
+        $edges = (new ServiceLocationEdgeFinder)->scanPaths([$fixtureDir]);
+
+        $this->assertCount(3, $edges);
+
+        $vias = array_map(static fn ($edge): string => $edge->via, $edges);
+        sort($vias);
+
+        $this->assertSame(['App::make', 'app', 'resolve'], $vias);
+
+        foreach ($edges as $edge) {
+            $this->assertSame(
+                'Neo4j\\LaravelBoost\\Tests\\Integration\\Fixtures\\StaticAnalysis\\Services\\OrderProcessor',
+                $edge->class,
+            );
+            $this->assertSame(
+                'Neo4j\\LaravelBoost\\Tests\\Integration\\Fixtures\\StaticAnalysis\\Services\\PaymentGateway',
+                $edge->dependency,
+            );
+            $this->assertSame('service_location', $edge->toDependencyRow()['type']);
+            $this->assertSame('static', $edge->toDependencyRow()['source']);
+        }
+    }
+
+    public function test_skips_dynamic_variable_service_locator_calls(): void
+    {
+        $source = <<<'PHP'
+<?php
+namespace Demo;
+
+use Illuminate\Support\Facades\App;
+
+class Worker
+{
+    public function run(string $abstract): void
+    {
+        app($abstract);
+        resolve($abstract);
+        App::make($abstract);
+    }
+}
+PHP;
+
+        $edges = (new ServiceLocationEdgeFinder)->scanSource($source);
+
+        $this->assertSame([], $edges);
+    }
+}


### PR DESCRIPTION
SOFT-43 POC: container:graph scans configured PHP paths for literal app(), resolve(), and App::make() calls and exports them as hidden DEPENDS_ON edges with type: service_location, source: static, plus via, file, and line. Scanning is opt-in via NEO4J_CONTAINER_GRAPH_STATIC_SCAN_PATHS; dynamic calls like app($variable) are skipped. Adds a PhpParser finder, PHPStan collector rules, Neo4j writer support, and unit/integration tests.