### PR TITLE
feat(container-graph): export facade resolution catalog as dependency…

### DIFF
--- a/README.md
+++ b/README.md
@@ -337,7 +337,7 @@ Static facade scanning consumes this catalog when resolving `Cache::put`-style c
 - `access` on `Dependency`: `di`, `facade`, `global_helper`, `service_location`
 - `lifetime` on `RESOLVES_TO`: `singleton`, `bind`
 - `Identifier.kind`: `Class`, `Interface`, `Alias`, or `Unresolved` (with optional `reason` on the node)
-- Facade/global-helper catalog entries will populate `Dependency → Identifier` chains once the resolution catalog lands (catalog-only rows have no `Instance` edge)
+- Facade catalog entries from the resolution catalog export as catalog-only `Dependency → Identifier` chains (`access: facade`, empty `instance`; `via` holds the facade class)
 
 There are no direct `DEPENDS_ON` edges from `Instance` to implementation classes.
 

--- a/src/Console/ContainerGraphCommand.php
+++ b/src/Console/ContainerGraphCommand.php
@@ -6,6 +6,7 @@ use Closure;
 use Illuminate\Console\Command;
 use Neo4j\LaravelBoost\ContainerGraph\DependencyChainBuilder;
 use Neo4j\LaravelBoost\ContainerGraphWriter;
+use Neo4j\LaravelBoost\ResolutionCatalog\FacadeCatalogExporter;
 use Neo4j\LaravelBoost\StaticAnalysis\FacadeEdgeFinder;
 use Neo4j\LaravelBoost\StaticAnalysis\ServiceLocationEdgeFinder;
 use Neo4j\LaravelBoost\Support\Graph\BindsToType;
@@ -29,6 +30,7 @@ class ContainerGraphCommand extends Command
         private ServiceLocationEdgeFinder $serviceLocationEdgeFinder,
         private FacadeEdgeFinder $facadeEdgeFinder,
         private DependencyChainBuilder $dependencyChainBuilder,
+        private FacadeCatalogExporter $facadeCatalogExporter,
     ) {
         parent::__construct();
     }
@@ -51,14 +53,17 @@ class ContainerGraphCommand extends Command
             static fn (string $className): array => ['class' => $className],
             $concreteClasses
         );
+        $facadeCatalogRows = $this->facadeCatalogExporter->rowsForAppClasses($concreteClasses);
         $dependencyChainRows = $this->buildDependencyChainRows(
             $dependencyRows,
             $unresolvedRows,
             $bindings,
+            $facadeCatalogRows,
         );
 
         $this->line('Container graph summary:');
         $this->line('- Bindings: '.count($bindingRows));
+        $this->line('- Facade catalog entries: '.count($facadeCatalogRows));
         $this->line('- Concrete classes inspected: '.count($concreteClasses));
         $this->line('- Instance nodes: '.count($instanceRows));
         $this->line('- Dependency chains: '.count($dependencyChainRows));
@@ -94,12 +99,14 @@ class ContainerGraphCommand extends Command
      * @param  array<int, array{class: string, dependency: string, dependencyKind: string, type: string, source?: string, via?: string, file?: string, line?: int}>  $dependencyRows
      * @param  array<int, array{class: string, name: string, reason: string, type: string}>  $unresolvedRows
      * @param  array<string, array{concrete: mixed, shared: bool}>  $bindings
+     * @param  array<int, array{facade_class: string, abstract: string, abstractKind: string, binding_key: string, source: string, binds_to_type: string}>  $facadeCatalogRows
      * @return array<int, array{instance: string, dependency_key: string, access: string, identifier: string, identifier_kind: string, lifetime: string, via: string, file: string, line: int}>
      */
     private function buildDependencyChainRows(
         array $dependencyRows,
         array $unresolvedRows,
         array $bindings,
+        array $facadeCatalogRows = [],
     ): array {
         $chains = [];
 
@@ -109,6 +116,10 @@ class ContainerGraphCommand extends Command
 
         foreach ($unresolvedRows as $row) {
             $chains[] = $this->dependencyChainBuilder->fromUnresolvedRow($row, $bindings);
+        }
+
+        foreach ($facadeCatalogRows as $row) {
+            $chains[] = $this->dependencyChainBuilder->fromFacadeExportRow($row);
         }
 
         return $this->uniqueRows($chains);

--- a/src/Neo4jBoostServiceProvider.php
+++ b/src/Neo4jBoostServiceProvider.php
@@ -23,6 +23,7 @@ use Neo4j\LaravelBoost\ResolutionCatalog\ContainerBindingAbstractResolver;
 use Neo4j\LaravelBoost\ResolutionCatalog\ContainerBindingLifetime;
 use Neo4j\LaravelBoost\ResolutionCatalog\CustomFacadeAccessorResolver;
 use Neo4j\LaravelBoost\ResolutionCatalog\FacadeAccessorParser;
+use Neo4j\LaravelBoost\ResolutionCatalog\FacadeCatalogExporter;
 use Neo4j\LaravelBoost\ResolutionCatalog\LaravelFirstPartyFacadeCatalog;
 use Neo4j\LaravelBoost\ResolutionCatalog\ResolutionCatalog;
 use Neo4j\LaravelBoost\StaticAnalysis\FacadeEdgeFinder;
@@ -55,6 +56,7 @@ class Neo4jBoostServiceProvider extends ServiceProvider
         $this->app->singleton(BindingLifetimeResolver::class);
         $this->app->singleton(DependencyChainBuilder::class);
         $this->app->singleton(LaravelFirstPartyFacadeCatalog::class);
+        $this->app->singleton(FacadeCatalogExporter::class);
         $this->app->singleton(FacadeAccessorParser::class);
         $this->app->singleton(ContainerBindingAbstractResolver::class);
         $this->app->singleton(ContainerBindingLifetime::class);

--- a/tests/Integration/ContainerGraphComplexDatasetTest.php
+++ b/tests/Integration/ContainerGraphComplexDatasetTest.php
@@ -2,6 +2,7 @@
 
 namespace Neo4j\LaravelBoost\Tests\Integration;
 
+use Illuminate\Support\Facades\Cache;
 use Neo4j\LaravelBoost\ContainerGraphWriter;
 use Neo4j\LaravelBoost\Tests\Integration\Fixtures\ContainerGraph\ComplexContainerRegistry;
 use Neo4j\LaravelBoost\Tests\Integration\Fixtures\ContainerGraph\Contracts\EventPusherInterface;
@@ -92,6 +93,17 @@ class ContainerGraphComplexDatasetTest extends TestCase
         $this->assertTrue($this->graph->hasInstanceNode(Firewall::class));
         $this->assertGreaterThanOrEqual(10, count($this->graph->bindingRows));
         $this->assertGreaterThanOrEqual(3, count($this->graph->dependencyChainRows));
+    }
+
+    public function test_complex_dataset_exports_facade_catalog_chains(): void
+    {
+        $this->runContainerGraph();
+
+        $cacheChain = $this->graph->findFacadeCatalogChain(Cache::class);
+        $this->assertNotNull($cacheChain);
+        $this->assertSame('cache', $cacheChain['identifier']);
+        $this->assertSame('singleton', $cacheChain['lifetime']);
+        $this->assertSame('facade|cache', $cacheChain['dependency_key']);
     }
 
     public function test_container_graph_dry_run_does_not_write_graph(): void

--- a/tests/Integration/Support/RecordingContainerGraphWriter.php
+++ b/tests/Integration/Support/RecordingContainerGraphWriter.php
@@ -81,6 +81,22 @@ class RecordingContainerGraphWriter extends ContainerGraphWriter
         return null;
     }
 
+    /**
+     * @return null|array{instance: string, dependency_key: string, access: string, identifier: string, identifier_kind: string, lifetime: string, via: string, file: string, line: int, reason?: string}
+     */
+    public function findFacadeCatalogChain(string $facadeClass): ?array
+    {
+        foreach ($this->dependencyChainRows as $row) {
+            if (($row['instance'] ?? '') === ''
+                && ($row['access'] ?? '') === 'facade'
+                && ($row['via'] ?? '') === $facadeClass) {
+                return $row;
+            }
+        }
+
+        return null;
+    }
+
     public function hasInstanceNode(string $class): bool
     {
         foreach ($this->instanceRows as $row) {


### PR DESCRIPTION
feat(container-graph): export facade resolution catalog as dependency chains

Wire FacadeCatalogExporter into container:graph so first-party and custom app facades write catalog-only Dependency→Identifier chains (access: facade).