### PR TITLE
Improve Neo4j Boost MCP Server Error Message for Missing Neo4j Instance

### DIFF
--- a/src/Console/ContainerGraphCommand.php
+++ b/src/Console/ContainerGraphCommand.php
@@ -5,6 +5,7 @@ namespace Neo4j\LaravelBoost\Console;
 use Closure;
 use Illuminate\Console\Command;
 use Neo4j\LaravelBoost\ContainerGraphWriter;
+use Neo4j\LaravelBoost\Support\Neo4jMcpHealth;
 use RecursiveDirectoryIterator;
 use RecursiveIteratorIterator;
 use ReflectionClass;
@@ -51,6 +52,7 @@ class ContainerGraphCommand extends Command
             $writer->connect();
             $writer->write($classRows, $bindingRows, $dependencyRows, $unresolvedRows);
         } catch (Throwable $e) {
+            $this->warn(Neo4jMcpHealth::noInstanceFoundMessage());
             $this->error('Failed to write container graph: '.$e->getMessage());
 
             return self::FAILURE;

--- a/src/Neo4jDriverClient.php
+++ b/src/Neo4jDriverClient.php
@@ -6,6 +6,7 @@ use Neo4j\LaravelBoost\Contracts\BoltExecutorInterface;
 use Neo4j\LaravelBoost\Contracts\Neo4jMcpClientInterface;
 use Neo4j\LaravelBoost\Support\CypherQueryClassifier;
 use Neo4j\LaravelBoost\Support\McpToolResult;
+use Neo4j\LaravelBoost\Support\Neo4jMcpHealth;
 use Throwable;
 
 /**
@@ -71,7 +72,7 @@ CYPHER;
                 return $this->getSchemaWithoutApoc();
             }
 
-            return McpToolResult::error($e->getMessage());
+            return $this->connectionErrorResult($e);
         }
     }
 
@@ -126,7 +127,7 @@ CYPHER;
 
             return McpToolResult::jsonRows(Neo4jBoltExecutor::summarizedResultToRows($result));
         } catch (Throwable $e) {
-            return McpToolResult::error($e->getMessage());
+            return $this->connectionErrorResult($e);
         }
     }
 
@@ -148,7 +149,7 @@ CYPHER;
 
             return McpToolResult::jsonRows(Neo4jBoltExecutor::summarizedResultToRows($result));
         } catch (Throwable $e) {
-            return McpToolResult::error($e->getMessage());
+            return $this->connectionErrorResult($e);
         }
     }
 
@@ -167,6 +168,30 @@ CYPHER;
                 .'. Ensure that the Graph Data Science (GDS) library is installed and properly configured in your Neo4j database.'
             );
         }
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function connectionErrorResult(Throwable $e): array
+    {
+        if ($this->isConnectionFailure($e)) {
+            return McpToolResult::error(Neo4jMcpHealth::noInstanceFoundMessage());
+        }
+
+        return McpToolResult::error($e->getMessage());
+    }
+
+    private function isConnectionFailure(Throwable $e): bool
+    {
+        $message = strtolower($e->getMessage());
+
+        return str_contains($message, 'connection refused')
+            || str_contains($message, 'connection timed out')
+            || str_contains($message, 'failed to connect')
+            || str_contains($message, 'no route to host')
+            || str_contains($message, 'could not connect')
+            || str_contains($message, 'unable to connect');
     }
 
     private function isApocMissing(Throwable $e): bool

--- a/src/Support/Neo4jMcpHealth.php
+++ b/src/Support/Neo4jMcpHealth.php
@@ -105,6 +105,7 @@ final class Neo4jMcpHealth
         }
 
         if ($transport === 'http' && ! $serverReachable) {
+            $suggestedResolutions[] = self::noInstanceFoundMessage();
             $suggestedResolutions[] = 'Start neo4j-mcp in HTTP mode and verify NEO4J_MCP_URL points to /mcp.';
             $suggestedResolutions[] = 'Verify Neo4j MCP auth settings (NEO4J_MCP_USERNAME / NEO4J_MCP_PASSWORD) if your endpoint requires authentication.';
         }
@@ -178,14 +179,31 @@ final class Neo4jMcpHealth
         return self::HTTP_AUTH_FAILED_MESSAGE;
     }
 
+    public static function noInstanceFoundMessage(): string
+    {
+        return implode("\n", [
+            'No Neo4j server was found.',
+            'To use the Neo4j Boost MCP Server, you\'ll need access to a Neo4j database.',
+            'You can create a free Neo4j Aura instance here: https://neo4j.com/product/auradb/',
+            'Once your database is ready, reconnect the MCP server and try again.',
+        ]);
+    }
+
     public static function serverUnreachableMessage(string $url): string
     {
-        return 'Neo4j MCP server is not reachable at '.$url.'. Start it or run php artisan neo4j-boost:setup.';
+        return self::noInstanceFoundMessage()
+            .'\n(Attempted URL: '.$url.' — start the server or run: php artisan neo4j-boost:setup)';
     }
 
     public static function stdioProcessFailedMessage(): string
     {
-        return 'Neo4j MCP STDIO process failed. Run php artisan neo4j-boost:setup and ensure the neo4j-mcp binary is installed.';
+        return implode("\n", [
+            'No Neo4j server was found.',
+            'To use the Neo4j Boost MCP Server, you\'ll need access to a Neo4j database.',
+            'You can create a free Neo4j Aura instance here: https://neo4j.com/product/auradb/',
+            'Once your database is ready, reconnect the MCP server and try again.',
+            '(The Neo4j MCP STDIO process failed — run: php artisan neo4j-boost:setup and ensure the neo4j-mcp binary is installed.)',
+        ]);
     }
 
     private function runningInTinker(): bool


### PR DESCRIPTION
Updated the Neo4j Boost MCP Server to display a clear, user-friendly prompt whenever no Neo4j server is found.

