### PR TITLE
Prepare v1.0.0 release documentation.

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -26,3 +26,6 @@ NEO4J_PASSWORD=
 # NEO4J_DEFAULT_CONNECTION_DSN=neo4j://neo4j:password@neo4j-core1:7687
 # NEO4J_USER=neo4j
 # NEO4J_PASSWORD=password
+# Optional: comma-separated absolute paths for hidden-dependency static scan (container:graph)
+# NEO4J_CONTAINER_GRAPH_STATIC_SCAN_PATHS=/var/www/html/app/Services
+# NEO4J_CONTAINER_GRAPH_STATIC_SCAN_PROVIDER_PATHS=/var/www/html/app/Providers

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,14 +7,28 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.0.0] - 2026-07-06
+
 ### Added
 
-- Method injection detection for controllers, jobs, commands, listeners, and middleware. `container:graph` emits `DEPENDS_ON` edges with `type: method_injection`, `method`, and `parameter` (includes Form Request types on controller actions).
-- Static scan for Laravel global helper usage (`cache`, `auth`, `view`, `response`, `redirect`, `route`, `event`, `dispatch`, `logger`, `session`, `config`, `env`). Exports `DEPENDS_ON` edges with `type: global_helper` and `helper`.
-- Static scan for direct class instantiation (`new ClassName()`). Exports `DEPENDS_ON` edges with `type: instantiation`, skipping PHP internal classes, anonymous classes, and dynamic class expressions.
-- Edge metadata on dependency graph relationships: `source`, `confidence`, `provenance`, and `remarks` on every `DEPENDS_ON` and `BINDS_TO` edge. MCP `get-class-dependency-graph` responses include `graph_completeness: partial` with documented limitations.
-- `get-class-dependency-graph` now returns `declared_dependencies` and `hidden_dependencies` buckets, per-dependency `visibility`, and a richer `graph_completeness` block with per-class `coverage`, declared/hidden counts, and active/pending detectors.
-- **contribute-graph-knowledge** MCP tool to add dependency or binding edges when static analysis cannot infer them.
+- **Three-node container dependency model** for `container:graph`: `Instance → DEPENDS_ON → Dependency → RESOLVES_TO → Identifier`, replacing direct class-to-class dependency edges.
+- **Static scan** (opt-in via `NEO4J_CONTAINER_GRAPH_STATIC_SCAN_PATHS`) for hidden dependencies:
+  - Service location (`app()`, `resolve()`, `App::make()` with literal class arguments; extended locators and dynamic-call handling).
+  - Facade static calls (`Cache::put`, custom `Facade::method`, real-time `\Facades\...` references), resolved via the resolution catalog with `catalog_source` metadata (`laravel_facade`, `auto_discovered_facade`).
+  - Global helper usage (`cache`, `auth`, `view`, `response`, `redirect`, `route`, `event`, `dispatch`, `logger`, `session`, `config`, `env`).
+  - Direct class instantiation (`new ClassName()`), skipping PHP internal classes, anonymous classes, and dynamic expressions.
+- **Method injection detection** for controllers, jobs, commands, listeners, and middleware. Exports `DEPENDS_ON` edges with `type: method_injection`, `method`, and `parameter` (includes Form Request types on controller actions).
+- **Contextual bindings** export: Laravel `when()->needs()->give()` overrides as `Instance-[:CONTEXTUAL_BINDS]->Identifier` edges.
+- **Facade resolution catalog** export and runtime resolution (first-party Laravel facades, custom app facades via `getFacadeAccessor()`, and real-time facades).
+- **Edge metadata** on every `DEPENDS_ON` and `BINDS_TO` relationship: `source`, `confidence`, `provenance`, and `remarks`.
+- **Enhanced `get-class-dependency-graph` MCP tool**: `declared_dependencies` and `hidden_dependencies` buckets, per-dependency `visibility`, and a richer `graph_completeness` block (`coverage`, declared/hidden counts, active/pending detectors).
+- **`contribute-graph-knowledge` MCP tool** to add dependency or binding edges when static analysis cannot infer them (with user confirmation for medium/low confidence).
+- Neo4j PHP driver User-Agent set to `Neo4j/Laravel-Boost`.
+
+### Changed
+
+- `container:graph` summary now reports method injection, static scan, contextual binding, and facade catalog counts.
+- MCP tool descriptions and Boost guidelines updated for the new graph model and metadata fields.
 
 ## [0.1.0] - 2026-04-29
 
@@ -30,4 +44,5 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - First public semver release under `neo4j/laravel-boost` (previously `1.0.0` placeholder in `composer.json`).
 
+[1.0.0]: https://github.com/neo4j-php/neo4j-boost/releases/tag/v1.0.0
 [0.1.0]: https://github.com/neo4j-php/neo4j-boost/releases/tag/v0.1.0

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Neo4j Laravel Boost
 
-Laravel integration for the [official Neo4j MCP server](https://github.com/neo4j/mcp/releases). Use Neo4j tools (get-schema, read-cypher, write-cypher, etc.) from MCP clients like Cursor or Claude.
+Laravel integration for the [official Neo4j MCP server](https://github.com/neo4j/mcp/releases). Use Neo4j tools (get-schema, read-cypher, write-cypher, list-gds-procedures, get-class-dependency-graph, contribute-graph-knowledge) from MCP clients like Cursor or Claude.
 
 Release notes: [CHANGELOG.md](CHANGELOG.md).
 
@@ -205,9 +205,14 @@ When developing the package and running Artisan from the repo (e.g. e2e testing 
 | Command | Description |
 |--------|-------------|
 | `php artisan neo4j-boost:cursor-config` | Create or update `.cursor/mcp.json` with the Neo4j MCP server URL (merge with existing servers) |
+| `php artisan neo4j-boost:setup` | Interactive STDIO-first setup (binary, env checks, Cursor config) |
+| `php artisan neo4j-boost:install-mcp` | Download/install the official `neo4j-mcp` binary |
+| `php artisan neo4j-boost:start-neo4j` | Start local Neo4j Docker for STDIO mode |
+| `php artisan neo4j-boost:doctor` | Diagnose transport, binary, password, and readiness |
+| `php artisan neo4j-boost:test-stdio --tool=get-schema` | Verbose end-to-end STDIO handshake/tool test |
 | `php artisan container:graph` | Export Laravel container bindings/dependencies into Neo4j graph (`--dry-run`, `--print-cypher`) |
 
-Neo4j tools exposed via Laravel Boost MCP (`php artisan boost:mcp`) include **get-class-dependency-graph**, which returns a structured dependency graph for a fully-qualified class (requires `container:graph` export first). Other tools: get-schema, read-cypher, write-cypher, list-gds-procedures.
+Neo4j tools exposed via Laravel Boost MCP (`php artisan boost:mcp`) include **get-class-dependency-graph** and **contribute-graph-knowledge** (container graph; require `container:graph` export first), plus get-schema, read-cypher, write-cypher, and list-gds-procedures.
 
 ---
 
@@ -444,6 +449,32 @@ For ad-hoc exploration you can still use **read-cypher**. For Laravel DI questio
 
 Returns structured JSON with `dependencies` (including `access`, `lifetime`, `source`, `confidence`, `provenance`, optional `remarks`, and `visibility`), `declared_dependencies`, `hidden_dependencies`, `dependents`, `binding`, pagination metadata (`dependencies_pagination` / `dependents_pagination`), `graph_completeness` (`status: partial` with known limitations, plus per-class `coverage` and declared/hidden counts), and `graph_export_required` when data is missing. Default page size is 100 entries.
 
+### contribute-graph-knowledge (MCP tool)
+
+Add dependency or binding edges when static analysis cannot infer them. Prerequisite: run `php artisan container:graph` first.
+
+| Field | Description |
+| --- | --- |
+| `relationship` | `DEPENDS_ON` or `BINDS_TO` |
+| `from` | Source fully-qualified class or interface |
+| `to` | Target fully-qualified class or interface |
+| `confidence` | `high` (persists immediately as `source: agent`), `medium` or `low` (returns `confirmation_required` until user confirms) |
+| `confirmed` | Set `true` after user confirms a medium/low proposal (persists as `source: user`) |
+| `reason` | Optional explanation |
+| `depends_on_type` | For `DEPENDS_ON`: `constructor_injection`, `method_injection`, `facade`, `global_helper`, `service_location`, or `instantiation` (default: `service_location`) |
+| `shared` | For `BINDS_TO`: whether the binding is a singleton |
+
+```json
+{
+  "relationship": "DEPENDS_ON",
+  "from": "App\\Services\\OrderProcessor",
+  "to": "App\\Contracts\\PaymentGateway",
+  "confidence": "high",
+  "depends_on_type": "service_location",
+  "reason": "Resolved manually from route action"
+}
+```
+
 **Explore bindings from container keys outward:**
 
 ```cypher
@@ -495,12 +526,7 @@ RETURN i.name, id.name, id.reason
 LIMIT 25;
 ```
 
-Re-running the command is idempotent (`MERGE`-based), so nodes/relationships are not duplicated.
-| `php artisan neo4j-boost:setup` | Interactive STDIO-first setup (binary, env checks, Cursor config) |
-| `php artisan neo4j-boost:install-mcp` | Download/install the official `neo4j-mcp` binary |
-| `php artisan neo4j-boost:start-neo4j` | Start local Neo4j Docker for STDIO mode |
-| `php artisan neo4j-boost:doctor` | Diagnose transport, binary, password, and readiness |
-| `php artisan neo4j-boost:test-stdio --tool=get-schema` | Verbose end-to-end STDIO handshake/tool test |
+Re-running `container:graph` is **merge-idempotent**: identical nodes and relationships are upserted via `MERGE` and are not duplicated. It does **not** remove edges from prior exports (for example after disabling static scan paths or upgrading graph schema). To replace the graph entirely, clear container-graph data in Neo4j before re-exporting, or use a dedicated database.
 
 ### Auto-install supported platforms (`neo4j-boost:install-mcp`)
 

--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,6 @@
 {
     "name": "neo4j/laravel-boost",
-    "version": "0.1.0",
+    "version": "1.0.0",
     "description": "Official Neo4j MCP server integration for Laravel",
     "type": "library",
     "license": "MIT",

--- a/resources/boost/guidelines/core.blade.php
+++ b/resources/boost/guidelines/core.blade.php
@@ -2,9 +2,9 @@
 
 This package integrates the official [Neo4j MCP](https://github.com/neo4j/mcp/releases) server into Laravel so you can use Neo4j tools from MCP clients (Cursor, Claude, etc.).
 
-### HTTP only
+### Transport modes
 
-The package talks to the Neo4j MCP server over **HTTP only**. Run the Neo4j MCP server elsewhere (e.g. Docker) with HTTP transport, then set in `.env`:
+The package supports **STDIO** (default — local `neo4j-mcp` binary), **HTTP** (remote MCP server), and **driver** (in-process Bolt via `NEO4J_MCP_TRANSPORT=driver`). For HTTP-only setups, run the Neo4j MCP server elsewhere (e.g. Docker) with HTTP transport, then set in `.env`:
 
 ```env
 NEO4J_MCP_URL=http://localhost:8080/mcp


### PR DESCRIPTION
Complete the changelog for the container graph epic, bump the package version to 1.0.0, fix broken README artisan table and idempotency wording, document contribute-graph-knowledge, and align Boost guidelines with supported transport modes.