### PR TITLE
Remove laravel/mcp:^0.5.1 dependency from laravel-boost

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -31,11 +31,11 @@
         "php": "^8.2",
         "laravel/framework": "^12.0|^13.0",
         "laravel/boost": "^2.0",
-        "laravel/mcp": "^0.5.1",
         "laudis/neo4j-php-client": "^3.4"
     },
     "require-dev": {
         "larastan/larastan": "^3.0",
+        "laravel/mcp": "^0.5.1",
         "laravel/pint": "^1.18",
         "nikic/php-parser": "^5.4",
         "orchestra/testbench": "^10.11|^11.0",


### PR DESCRIPTION
The laravel/mcp:^0.5.1 package is currently included as a production dependency in laravel-boost. This dependency is only required for development purposes and should not be installed in production environments.