### PR TITLE
Change default MCP transport from stdio to driver.

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -7,11 +7,12 @@ APP_DEBUG=true
 APP_KEY=
 
 # Neo4j MCP transport mode:
-# - stdio (default): runs the local neo4j-mcp binary.
+# - driver (default): in-process Bolt via laudis/neo4j-php-client — no neo4j-mcp binary required.
+# - stdio: runs the local neo4j-mcp binary (set NEO4J_MCP_TRANSPORT=stdio).
 # - http: use when the MCP server runs elsewhere and NEO4J_MCP_URL points to it.
-NEO4J_MCP_TRANSPORT=stdio
+# NEO4J_MCP_TRANSPORT=driver
 
-# Neo4j database credentials (required for STDIO mode — passed to the neo4j-mcp subprocess)
+# Neo4j database credentials (used by driver, stdio, and container:graph)
 NEO4J_URI=bolt://localhost:7687
 NEO4J_USERNAME=neo4j
 NEO4J_PASSWORD=

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Default `NEO4J_MCP_TRANSPORT` is now **`driver`** (in-process Bolt) instead of `stdio`. Set `NEO4J_MCP_TRANSPORT=stdio` explicitly to use the `neo4j-mcp` binary.
+
 ## [1.0.0] - 2026-07-06
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -6,6 +6,35 @@ Release notes: [CHANGELOG.md](CHANGELOG.md).
 
 **Requirements:** PHP 8.2+, Laravel 12 or 13, [Laravel Boost](https://github.com/laravel/boost).
 
+## Table of contents
+
+- [CI (this repository)](#ci-this-repository)
+- [Workbench (`composer run serve`)](#workbench-composer-run-serve)
+- [Installation](#installation)
+  - [1. Install the package](#1-install-the-package)
+  - [2. Configure Neo4j connection](#2-configure-neo4j-connection)
+  - [3. (Optional) Run interactive setup](#3-optional-run-interactive-setup)
+  - [4. (Optional) Cursor MCP config](#4-optional-cursor-mcp-config)
+  - [5. Alternative transports (STDIO / HTTP)](#5-alternative-transports-stdio--http)
+  - [6. (Optional) Enable GDS](#6-optional-enable-gds-for-list-gds-procedures)
+- [Single MCP server with Laravel Boost](#single-mcp-server-with-laravel-boost)
+- [Using with Cursor](#using-with-cursor)
+- [Local development (this repo)](#local-development-this-repo)
+- [Artisan commands](#artisan-commands)
+- [Container Graph POC (LLM Debugging)](#container-graph-poc-llm-debugging)
+  - [Environment variables](#environment-variables)
+  - [Run](#run)
+  - [Static analysis pass](#static-analysis-pass)
+  - [Resolution catalog](#resolution-catalog-facade--contract)
+  - [Method injection](#method-injection)
+  - [Graph model](#graph-model)
+  - [Example Cypher queries](#example-cypher-queries)
+  - [contribute-graph-knowledge (MCP tool)](#contribute-graph-knowledge-mcp-tool)
+  - [Auto-install supported platforms](#auto-install-supported-platforms-neo4j-boostinstall-mcp)
+- [Configuration](#configuration)
+- [Troubleshooting](#troubleshooting)
+- [License](#license)
+
 ### CI (this repository)
 
 GitHub Actions include four workflows on a **PHP × Laravel** matrix compatible with upstream constraints: **Laravel 12** on PHP **8.2** and **8.5**; **Laravel 13** (requires PHP **^8.3**) on PHP **8.3** and **8.5**. Workflows: [Pint](https://github.com/laravel/pint) (`.github/workflows/pint.yml`), [PHPStan](https://phpstan.org/) + [Larastan](https://github.com/larastan/larastan) (`.github/workflows/phpstan.yml`), PHPUnit (`.github/workflows/phpunit.yml`), and **[Testbench](https://packages.tools/testbench.html)** (`.github/workflows/testbench.yml`) — which runs `composer run build` then PHPUnit against [`Orchestra\Testbench\TestCase`](tests/TestCase.php).
@@ -35,27 +64,31 @@ The [Orchestra Testbench](https://packages.tools/testbench.html) workbench is a 
 composer require neo4j/laravel-boost
 ```
 
-### 2. Run interactive setup
+### 2. Configure Neo4j connection
+
+By default the package uses **driver** transport — Neo4j tools run in PHP over Bolt (`laudis/neo4j-php-client`). No `neo4j-mcp` binary is required. Add to your `.env`:
+
+```env
+NEO4J_URI=bolt://localhost:7687
+NEO4J_USERNAME=neo4j
+NEO4J_PASSWORD=your-password
+```
+
+`NEO4J_MCP_TRANSPORT` defaults to `driver`; you only need to set it when using STDIO or HTTP (see [Alternative transports](#5-alternative-transports-stdio--http)).
+
+### 3. (Optional) Run interactive setup
 
 ```bash
 php artisan neo4j-boost:setup
 ```
 
-By default, this package uses **STDIO transport** and manages the official `neo4j-mcp` binary directly for local usage.  
-The setup command installs/checks the binary, validates STDIO requirements, keeps `NEO4J_MCP_TRANSPORT=stdio`, and writes Cursor MCP config.
-
-### 3. Start local Neo4j (for STDIO mode)
+This can start a local Docker Neo4j instance on first run, write Cursor MCP config, and optionally install the `neo4j-mcp` binary (only needed for `NEO4J_MCP_TRANSPORT=stdio`).
 
 ```bash
 php artisan neo4j-boost:start-neo4j
 ```
 
-This command starts a local Docker Neo4j instance on:
-
-- `bolt://localhost:7687`
-- `http://localhost:7474`
-
-It also configures APOC defaults required by schema tools.
+Starts Neo4j on `bolt://localhost:7687` and `http://localhost:7474` with APOC defaults for schema tools.
 
 ### Optional: automate setup with a Composer hook
 
@@ -71,27 +104,7 @@ Add this to your app `composer.json` to run setup automatically after `composer 
 }
 ```
 
-### 4. Configure Neo4j connection (for the MCP server)
-
-For STDIO mode, the `neo4j-mcp` binary still needs Neo4j credentials. If you use Laravel’s Neo4j driver elsewhere, add to your `.env`:
-
-```env
-NEO4J_TRANSPORT_MODE=stdio
-NEO4J_URI=bolt://localhost:7687
-NEO4J_USERNAME=neo4j
-NEO4J_PASSWORD=your-password
-```
-
-For full local clarity, a complete example is:
-
-```env
-NEO4J_TRANSPORT_MODE=stdio
-NEO4J_URI=bolt://localhost:7687
-NEO4J_USERNAME=neo4j
-NEO4J_PASSWORD=password
-```
-
-### 5. (Optional) Cursor MCP config
+### 4. (Optional) Cursor MCP config
 
 To add/update Cursor MCP config:
 
@@ -101,9 +114,20 @@ php artisan neo4j-boost:cursor-config
 
 This creates or updates `.cursor/mcp.json` for the Boost MCP entry, merged with any existing servers.
 
-### 6. Advanced / Custom Server (HTTP or Docker)
+### 5. Alternative transports (STDIO / HTTP)
 
-If you want to run Neo4j MCP as a separate server instead of local STDIO binary mode:
+**STDIO** — use the official `neo4j-mcp` binary as a subprocess:
+
+```env
+NEO4J_MCP_TRANSPORT=stdio
+NEO4J_URI=bolt://localhost:7687
+NEO4J_USERNAME=neo4j
+NEO4J_PASSWORD=your-password
+```
+
+Install the binary with `php artisan neo4j-boost:install-mcp` or via `neo4j-boost:setup`.
+
+**HTTP** — connect to a remote or containerized MCP server:
 
 - Set `NEO4J_MCP_TRANSPORT=http`
 - Set `NEO4J_MCP_URL=http://localhost:8080/mcp` (or your remote URL)
@@ -119,7 +143,7 @@ docker run --rm -p 8080:8080 \
   docker.io/mcp/neo4j:latest
 ```
 
-### 7. (Optional) Enable GDS for `list-gds-procedures`
+### 6. (Optional) Enable GDS for `list-gds-procedures`
 
 The **list-gds-procedures** tool requires the [Graph Data Science](https://neo4j.com/docs/graph-data-science/current/) (GDS) plugin in Neo4j. Without it, that tool will error; other tools (get-schema, read-cypher, write-cypher) still work.
 
@@ -153,14 +177,14 @@ This package requires [Laravel Boost](https://github.com/laravel/boost) and auto
    composer require laravel/boost laravel/mcp neo4j/laravel-boost
    ```
 
-   For local development, default to STDIO and run:
+   For local development with driver transport (default), set Neo4j credentials in `.env` and optionally run:
 
    ```bash
    php artisan neo4j-boost:setup
    php artisan neo4j-boost:start-neo4j
    ```
 
-   If you prefer a remote/custom MCP server, set `NEO4J_MCP_TRANSPORT=http` and `NEO4J_MCP_URL=...`.
+   For STDIO or HTTP instead, see [Alternative transports](#5-alternative-transports-stdio--http).
 
 2. Use **one** Cursor MCP entry that runs Laravel Boost:
 
@@ -178,7 +202,7 @@ This package requires [Laravel Boost](https://github.com/laravel/boost) and auto
 
    **If your workspace is this package repo** (neo4j-boost): the `env` block is required so Laravel Boost registers its commands. In a normal Laravel app with `.env` already set to `APP_ENV=local`, you can omit `env` if you prefer.
 
-3. This package adds its Neo4j tools to Boost's tool list. You get Boost tools (search-docs, browser-logs, database, etc.) **and** the official Neo4j tools (get-schema, read-cypher, write-cypher, list-gds-procedures). Neo4j tools call the official server over STDIO by default, or over HTTP when `NEO4J_MCP_TRANSPORT=http`.
+3. This package adds its Neo4j tools to Boost's tool list. You get Boost tools (search-docs, browser-logs, database, etc.) **and** the official Neo4j tools (get-schema, read-cypher, write-cypher, list-gds-procedures). Neo4j tools use **driver** transport by default (Bolt in PHP); set `NEO4J_MCP_TRANSPORT=stdio` or `http` to change that.
 
 
 ---
@@ -187,7 +211,7 @@ This package requires [Laravel Boost](https://github.com/laravel/boost) and auto
 
 1. Open your **Laravel application folder** (the project where you ran `composer require`) as the Cursor workspace—not the neo4j-boost package directory.
 2. Reload Cursor or open MCP settings so it picks up `.cursor/mcp.json`.
-3. Enable **laravel-boost** (one MCP server via `php artisan boost:mcp`). Cursor uses stdio; this package calls Neo4j MCP over HTTP internally. Tools (get-schema, read-cypher, write-cypher, list-gds-procedures) appear when the server is connected.
+3. Enable **laravel-boost** (one MCP server via `php artisan boost:mcp`). Cursor talks to Boost over stdio; this package connects to Neo4j via driver (default), STDIO, or HTTP depending on `NEO4J_MCP_TRANSPORT`.
 
 ---
 
@@ -205,7 +229,7 @@ When developing the package and running Artisan from the repo (e.g. e2e testing 
 | Command | Description |
 |--------|-------------|
 | `php artisan neo4j-boost:cursor-config` | Create or update `.cursor/mcp.json` with the Neo4j MCP server URL (merge with existing servers) |
-| `php artisan neo4j-boost:setup` | Interactive STDIO-first setup (binary, env checks, Cursor config) |
+| `php artisan neo4j-boost:setup` | Interactive setup (Neo4j Docker, optional MCP binary, Cursor config) |
 | `php artisan neo4j-boost:install-mcp` | Download/install the official `neo4j-mcp` binary |
 | `php artisan neo4j-boost:start-neo4j` | Start local Neo4j Docker for STDIO mode |
 | `php artisan neo4j-boost:doctor` | Diagnose transport, binary, password, and readiness |
@@ -558,7 +582,7 @@ php artisan vendor:publish --tag=neo4j-boost-config
 
 Edit `config/neo4j-boost.php`:
 
-- **`neo4j_mcp.transport`** – How Neo4j MCP tools run (`stdio` default, `http`, or `driver` for in-process Bolt). Env: `NEO4J_MCP_TRANSPORT`.
+- **`neo4j_mcp.transport`** – How Neo4j MCP tools run (`driver` default, `stdio`, or `http`). Env: `NEO4J_MCP_TRANSPORT`.
 - **`bolt.uri`** / **`bolt.username`** / **`bolt.password`** – Bolt connection when `NEO4J_MCP_TRANSPORT=driver`. Env: `NEO4J_URI`, `NEO4J_USERNAME`, `NEO4J_PASSWORD` (or `NEO4J_DEFAULT_CONNECTION_DSN`).
 - **`neo4j_mcp.binary_path`** / **`neo4j_mcp.version`** – Local binary install path and version.
 - **`http.url`** – MCP endpoint (e.g. `http://localhost:8080/mcp`). Env: `NEO4J_MCP_URL`.
@@ -590,7 +614,7 @@ Edit `config/neo4j-boost.php`:
 
 - **HTTP 404: "This server only handles requests to /mcp"**  
   Cursor may try several connection methods (streamable HTTP, SSE) and can send **GET** requests. The official Neo4j MCP server in HTTP mode typically only accepts **POST** on `/mcp`, so those GETs return this 404.  
-  **Recommended:** Use **Laravel Boost** so Cursor talks to one MCP server over stdio (`php artisan boost:mcp`). This package then calls the Neo4j MCP server over HTTP (POST only) from your app; Cursor never hits the Neo4j HTTP URL directly.  
+  **Recommended:** Use **Laravel Boost** so Cursor talks to one MCP server over stdio (`php artisan boost:mcp`). This package then talks to Neo4j via driver (default), HTTP, or STDIO from your app; Cursor never hits the Neo4j HTTP URL directly.  
   If you must connect Cursor directly to the Neo4j MCP URL: ensure the URL in `.cursor/mcp.json` ends with `/mcp` (run `php artisan neo4j-boost:cursor-config` to normalize it) and that the Neo4j MCP server is running with `NEO4J_TRANSPORT_MODE=http`. Compatibility depends on the client using POST to the configured URL.
 
 - **GDS errors**  

--- a/config/neo4j-boost.php
+++ b/config/neo4j-boost.php
@@ -8,22 +8,22 @@ return [
     |
     | How this package talks to the Neo4j MCP server:
     |
-    | - http  : Connect to a remote MCP server over HTTP (e.g. a separate
-    |           neo4j-mcp process or container). Set NEO4J_MCP_TRANSPORT=http
-    |           and configure the "http" section below.
+    | - driver : Run MCP tools in PHP via laudis/neo4j-php-client (Bolt). No
+    |           neo4j-mcp binary required. This is the default. Set
+    |           NEO4J_URI / NEO4J_USERNAME / NEO4J_PASSWORD (or DSN).
     |
     | - stdio  : Run the MCP server as a subprocess and talk over stdin/stdout.
     |           Set NEO4J_MCP_TRANSPORT=stdio and configure the "stdio" section.
     |           The subprocess receives NEO4J_URI, NEO4J_USERNAME, NEO4J_PASSWORD
     |           from transport.stdio.env so it can connect to Neo4j.
     |
-    | - driver : Run MCP tools in PHP via laudis/neo4j-php-client (Bolt). No
-    |           neo4j-mcp binary required. Set NEO4J_MCP_TRANSPORT=driver and
-    |           NEO4J_URI / NEO4J_USERNAME / NEO4J_PASSWORD (or DSN).
+    | - http   : Connect to a remote MCP server over HTTP (e.g. a separate
+    |           neo4j-mcp process or container). Set NEO4J_MCP_TRANSPORT=http
+    |           and configure the "http" section below.
     |
     */
     'transport' => [
-        'driver' => env('NEO4J_MCP_TRANSPORT', 'stdio'),
+        'driver' => env('NEO4J_MCP_TRANSPORT', 'driver'),
         'stdio' => [
             'command' => env('NEO4J_MCP_STDIO_COMMAND', 'neo4j-mcp'),
             'env' => [
@@ -41,7 +41,7 @@ return [
     ],
 
     'neo4j_mcp' => [
-        'transport' => env('NEO4J_MCP_TRANSPORT', 'stdio'),
+        'transport' => env('NEO4J_MCP_TRANSPORT', 'driver'),
         'version' => env('NEO4J_MCP_VERSION', 'v1.4.0'),
         'binary_path' => env('NEO4J_MCP_BINARY_PATH'),
         'platform_asset' => env('NEO4J_MCP_PLATFORM_ASSET'),

--- a/resources/boost/guidelines/core.blade.php
+++ b/resources/boost/guidelines/core.blade.php
@@ -2,9 +2,18 @@
 
 This package integrates the official [Neo4j MCP](https://github.com/neo4j/mcp/releases) server into Laravel so you can use Neo4j tools from MCP clients (Cursor, Claude, etc.).
 
+### Index
+
+- [Transport modes](#transport-modes)
+- [Cursor config](#cursor-config)
+- [Run the MCP server](#run-the-mcp-server)
+- [Config](#config)
+- [Container graph POC](#container-graph-poc)
+- [Cursor: "Loading tools" stuck or HTTP 404](#cursor-loading-tools-stuck-or-http-404)
+
 ### Transport modes
 
-The package supports **STDIO** (default — local `neo4j-mcp` binary), **HTTP** (remote MCP server), and **driver** (in-process Bolt via `NEO4J_MCP_TRANSPORT=driver`). For HTTP-only setups, run the Neo4j MCP server elsewhere (e.g. Docker) with HTTP transport, then set in `.env`:
+The package supports **driver** (default — in-process Bolt via `laudis/neo4j-php-client`, no `neo4j-mcp` binary), **STDIO** (`NEO4J_MCP_TRANSPORT=stdio` — local `neo4j-mcp` binary), and **HTTP** (remote MCP server). For HTTP-only setups, run the Neo4j MCP server elsewhere (e.g. Docker) with HTTP transport, then set in `.env`:
 
 ```env
 NEO4J_MCP_URL=http://localhost:8080/mcp
@@ -24,7 +33,7 @@ This creates or updates `.cursor/mcp.json` with the server URL from config (merg
 
 ### Run the MCP server
 
-- **With Laravel Boost:** Use a single MCP server: run `php artisan boost:mcp`. This package adds the official Neo4j tools (get-schema, read-cypher, write-cypher, list-gds-procedures, **get-class-dependency-graph**, **contribute-graph-knowledge**) to Boost’s server automatically. Tools call the HTTP MCP URL from `config/neo4j-boost.http` except **get-class-dependency-graph** and **contribute-graph-knowledge**, which read/write the container graph directly from Neo4j using `config/neo4j-boost.container_graph`.
+- **With Laravel Boost:** Use a single MCP server: run `php artisan boost:mcp`. This package adds the official Neo4j tools (get-schema, read-cypher, write-cypher, list-gds-procedures, **get-class-dependency-graph**, **contribute-graph-knowledge**) to Boost’s server automatically. By default, tools use **driver** transport (Bolt in PHP). Set `NEO4J_MCP_TRANSPORT=http` or `stdio` to change that. **get-class-dependency-graph** and **contribute-graph-knowledge** always read/write the container graph directly from Neo4j using `config/neo4j-boost.container_graph`.
 - **Without Boost:** Add the Neo4j MCP server to Cursor as an HTTP server. Run `php artisan neo4j-boost:cursor-config` so `.cursor/mcp.json` includes the `neo4j-boost` server with the configured URL.
 
 Set `NEO4J_URI`, `NEO4J_USERNAME`, and `NEO4J_PASSWORD` where the Neo4j MCP server runs (and in Laravel if you use the Neo4j driver).
@@ -74,4 +83,4 @@ NEO4J_CONTAINER_GRAPH_STATIC_SCAN_PATHS=/var/www/html/app/Services
 - Open your **Laravel app folder** (the project where you ran `composer require neo4j/laravel-boost`) as the Cursor workspace, not the neo4j-boost package folder.
 - If `.cursor/mcp.json` is missing, run `php artisan neo4j-boost:cursor-config` to create it.
 - Ensure the Neo4j MCP server is running at the URL set in `NEO4J_MCP_URL` and that it is started with HTTP transport.
-- If you see **404 "This server only handles requests to /mcp"**: Cursor may send GET requests (e.g. for SSE); the Neo4j MCP server only accepts POST on `/mcp`. Using **Boost** (one server: `boost:mcp`) avoids this—Cursor uses stdio and this package calls Neo4j MCP over HTTP. Otherwise ensure the URL ends with `/mcp` and the server is running with HTTP transport.
+- If you see **404 "This server only handles requests to /mcp"**: Cursor may send GET requests (e.g. for SSE); the Neo4j MCP server only accepts POST on `/mcp`. Using **Boost** (one server: `boost:mcp`) avoids this—Cursor uses stdio to Laravel and this package talks to Neo4j via driver (default), HTTP, or STDIO. Otherwise ensure the URL ends with `/mcp` and the server is running with HTTP transport.

--- a/src/Console/SetupCommand.php
+++ b/src/Console/SetupCommand.php
@@ -13,7 +13,7 @@ class SetupCommand extends Command
                             {--skip-mcp : Skip Neo4j MCP binary installation}
                             {--no-cursor-config : Skip running neo4j-boost:cursor-config}';
 
-    protected $description = 'Interactive setup for Neo4j Laravel Boost (STDIO binary + Cursor config). Use -n/--no-interaction for manual steps only.';
+    protected $description = 'Interactive setup for Neo4j Laravel Boost (Neo4j, optional MCP binary, Cursor config). Use -n/--no-interaction for manual steps only.';
 
     public function handle(): int
     {
@@ -60,6 +60,14 @@ class SetupCommand extends Command
 
         $this->newLine();
 
+        $transport = Neo4jMcpConfig::transport();
+
+        if ($transport === 'driver' && Neo4jMcpConfig::hasNeo4jPassword()) {
+            $this->components->info('Neo4j Laravel Boost setup complete. Driver transport is ready (Bolt — no neo4j-mcp binary required).');
+
+            return self::SUCCESS;
+        }
+
         if ($installer->isInstalled() && Neo4jMcpConfig::hasNeo4jPassword()) {
             $this->components->info('Neo4j Laravel Boost setup complete. STDIO transport is ready with the local neo4j-mcp binary.');
 
@@ -81,11 +89,10 @@ class SetupCommand extends Command
     {
         $this->newLine();
         $this->components->info('Neo4j Laravel Boost setup');
-        $this->line('Default proxy path: <fg=cyan>Boost MCP -> STDIO -> neo4j-mcp binary</>');
-        $this->line('STDIO is the default transport, so installing the binary is enough for local setup.');
+        $this->line('Default path: <fg=cyan>Boost MCP -> driver transport (in-process Bolt)</>');
+        $this->line('No neo4j-mcp binary is required unless you set <fg=cyan>NEO4J_MCP_TRANSPORT=stdio</>.');
         $this->newLine();
         $this->line('Add these lines to your <fg=cyan>.env</> (reminder):');
-        $this->line('  <fg=gray>NEO4J_TRANSPORT_MODE=stdio</>');
         $this->line('  <fg=gray>NEO4J_URI=bolt://localhost:7687</>');
         $this->line('  <fg=gray>NEO4J_USERNAME=neo4j</>');
         $this->line('  <fg=gray>NEO4J_PASSWORD=password</>');
@@ -103,12 +110,14 @@ class SetupCommand extends Command
         $this->line('     <fg=gray>php artisan neo4j-boost:start-neo4j</>');
         $this->newLine();
         $this->line('  3. Ensure .env contains:');
-        $this->line('     <fg=gray>NEO4J_TRANSPORT_MODE=stdio</>');
         $this->line('     <fg=gray>NEO4J_URI=bolt://localhost:7687</>');
         $this->line('     <fg=gray>NEO4J_USERNAME=neo4j</>');
         $this->line('     <fg=gray>NEO4J_PASSWORD=password</>');
         $this->newLine();
-        $this->line('  4. Configure Cursor MCP:');
+        $this->line('  4. (Optional) For STDIO transport, also run install-mcp and set:');
+        $this->line('     <fg=gray>NEO4J_MCP_TRANSPORT=stdio</>');
+        $this->newLine();
+        $this->line('  5. Configure Cursor MCP:');
         $this->line('     <fg=gray>php artisan neo4j-boost:cursor-config</>');
         $this->newLine();
     }
@@ -125,6 +134,13 @@ class SetupCommand extends Command
 
         if (! $this->canPromptInteractively()) {
             return false;
+        }
+
+        if (Neo4jMcpConfig::transport() === 'driver') {
+            return $this->confirm(
+                'Install the official Neo4j MCP server binary? (only required for NEO4J_MCP_TRANSPORT=stdio)',
+                false
+            );
         }
 
         return $this->confirm(

--- a/src/Neo4jBoostServiceProvider.php
+++ b/src/Neo4jBoostServiceProvider.php
@@ -54,7 +54,7 @@ class Neo4jBoostServiceProvider extends ServiceProvider
         $this->app->singleton(BoltExecutorInterface::class, Neo4jBoltExecutor::class);
 
         $this->app->singleton(Neo4jMcpClientInterface::class, function ($app) {
-            $driver = strtolower((string) config('neo4j-boost.neo4j_mcp.transport', 'stdio'));
+            $driver = strtolower((string) config('neo4j-boost.neo4j_mcp.transport', 'driver'));
 
             return match ($driver) {
                 'driver' => new Neo4jDriverClient($app->make(BoltExecutorInterface::class)),

--- a/src/Support/Neo4jMcpConfig.php
+++ b/src/Support/Neo4jMcpConfig.php
@@ -11,7 +11,7 @@ final class Neo4jMcpConfig
         $transport = config('neo4j-boost.neo4j_mcp.transport');
 
         if (! is_string($transport) || $transport === '') {
-            $transport = config('neo4j-boost.transport.driver', 'stdio');
+            $transport = config('neo4j-boost.transport.driver', 'driver');
         }
 
         return strtolower((string) $transport);

--- a/tests/Integration/Neo4jBoostServiceProviderTest.php
+++ b/tests/Integration/Neo4jBoostServiceProviderTest.php
@@ -13,8 +13,18 @@ use Neo4j\LaravelBoost\Tests\TestCase;
 
 class Neo4jBoostServiceProviderTest extends TestCase
 {
-    public function test_resolves_neo4j_mcp_client_as_stdio_by_default(): void
+    public function test_resolves_neo4j_mcp_client_as_driver_by_default(): void
     {
+        $client = $this->app->make(Neo4jMcpClientInterface::class);
+
+        $this->assertInstanceOf(Neo4jDriverClient::class, $client);
+    }
+
+    public function test_resolves_neo4j_mcp_client_as_stdio_when_transport_is_stdio(): void
+    {
+        config(['neo4j-boost.neo4j_mcp.transport' => 'stdio']);
+
+        $this->app->forgetInstance(Neo4jMcpClientInterface::class);
         $client = $this->app->make(Neo4jMcpClientInterface::class);
 
         $this->assertInstanceOf(Neo4jStdioClient::class, $client);


### PR DESCRIPTION
Fresh installs now use in-process Bolt without the neo4j-mcp binary. Update setup messaging, env example, changelog, and README with a table of contents for quicker navigation.